### PR TITLE
Add service types and VM associations

### DIFF
--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -7,6 +7,14 @@ module ManageIQ
       Query = ::GraphQL::ObjectType.define do
         name 'Query'
 
+        field :service, Service, "Look up a service by its ID" do
+          argument :id, types.ID
+
+          resolve -> (obj, args, ctx) {
+            ::Service.find(args[:id])
+          }
+        end
+
         field :services, !types[Types::Service], "List available services" do
           resolve -> (obj, args, ctx) {
             ::Service.all

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -21,6 +21,14 @@ module ManageIQ
           }
         end
 
+        field :vm, Vm, "Look up a virtual machine by its ID" do
+          argument :id, types.ID
+
+          resolve -> (obj, args, ctx) {
+            ::Vm.find(args[:id])
+          }
+        end
+
         field :vms, !types[Types::Vm], "List available virtual machines" do
           resolve -> (obj, args, ctx) {
             ::Vm.all

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -1,3 +1,4 @@
+require 'manageiq/graphql/types/service'
 require 'manageiq/graphql/types/vm'
 
 module ManageIQ
@@ -5,6 +6,12 @@ module ManageIQ
     module Types
       Query = ::GraphQL::ObjectType.define do
         name 'Query'
+
+        field :services, !types[Types::Service], "List available services" do
+          resolve -> (obj, args, ctx) {
+            ::Service.all
+          }
+        end
 
         field :vms, !types[Types::Vm], "List available virtual machines" do
           resolve -> (obj, args, ctx) {

--- a/lib/manageiq/graphql/types/service.rb
+++ b/lib/manageiq/graphql/types/service.rb
@@ -1,0 +1,24 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      Service = ::GraphQL::ObjectType.define do
+        name 'Service'
+        description 'A Service is an item in a Service Catalog that can be requested.'
+
+        field :id, !types.ID, "The ID of the service"
+        field :name, !types.String, "The name of the service"
+        field :description, !types.String, "A human-readable description of the service"
+        field :guid, !types.ID, "The globally unique identifier of the service"
+        field :type, !types.String, "The service type"
+        field :display, !types.Boolean, "A true/false value determining if the service should be displayed"
+        field :retired, !types.Boolean, "A true/false value as to whether the service is retired or not"
+        field :retires_on, !types.String, "A string representation of the date this service is to be retired"
+        field :vms, types[Vm], "The virtual machines associated with this service" do
+          resolve ->(object, args, ctx) {
+            object.vms
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/vm.rb
+++ b/lib/manageiq/graphql/types/vm.rb
@@ -3,7 +3,7 @@ module ManageIQ
     module Types
       Vm = ::GraphQL::ObjectType.define do
         name 'Vm'
-        description 'A software implementation of a system that functions similar to a physical machine. Virtual machines utilize the hardware infrastructure of a physical host, or a set of physical hosts, to provide a scalable and on-demand method of system provisioning.'
+        description 'A Virtual Machine is a software implementation of a system that functions similar to a physical machine. Virtual machines utilize the hardware infrastructure of a physical host, or a set of physical hosts, to provide a scalable and on-demand method of system provisioning.'
 
         field :id, !types.ID, "The ID of the virtual machine"
         field :vendor, !types.String, "The virtual machine's vendor"
@@ -19,14 +19,15 @@ module ManageIQ
         field :previous_state, !types.String
         field :last_perf_capture_on, !types.String, "The timestamp of when the last metrics collection occurred for this virtual machine"
         field :template, !types.Boolean
-        field :miq_group_id, !types.ID
         field :type, !types.String
         field :ems_ref, !types.ID
-        field :flavor_id, !types.ID
         field :cloud, !types.Boolean
         field :raw_power_state, !types.String
-        field :tenant_id, !types.ID
-        # field :actions, !types.?
+        field :service, Service, "The service object associated with this virtual machine" do
+          resolve ->(object, args, ctx) {
+            object.service
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
This adds the equivalent of `/api/service/:id`, `/api/services`, and `/api/vm/:id` in the current REST API.

It demonstrates how GraphQL works with associations and how it would replace our maintaining our own version of requesting individual attributes across associations. It also shows that such associations can be *strongly typed* and self-documented given an example of someone who just had this issue in the REST API:


> Give me the names of the service associated with this VM:

`/api/vms/20000000000108?attributes=service.name` (works in REST API, yay)

Here, you'd do the following:

```
{
  vm(id: 20000000001208) {
    service {
      name
    }
  }
}
```

> Ok, now give me the names of the VMs associated with this service:

`/api/services/20000000000108?attributes=vms.name`

This DOESN'T currently work in the REST API, it's a bug or otherwise isn't implemented, and it's really hard to tell if it should work or not without manual documentation just stating it as truth.

In GraphQL, because we have a strongly typed schema to prove it, we know that this sort of query *will* work, even though we didn't implement this exact query explicitly:

```
{
  service(id: 20000000000108) {
    vms {
      name
    }
  }
}
```

What's more is the introspective property of this, using GraphiQL, could tell you whether or not that query should work - live documentation as code.

:warning: This PR purposes uses a very naive way of queries Vms and Services. The queries above, for example, generate N+1's. Finding how easy it is to batch queries is next!