### PR TITLE
Add Basic Authentication

### DIFF
--- a/spec/api/authentication_spec.rb
+++ b/spec/api/authentication_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe "Authentication" do
+  describe "basic authentication" do
+    it "authenticates a user with good credentials" do
+      user = User.create!(:name => "Alice", :userid => "Alice", :password => "letmein")
+
+      post(
+        "http://example.com/graphql",
+        :headers => {
+          "HTTP_AUTHORIZATION" => encode_credentials(user.userid, user.password)
+        },
+        :params => {:query => "{ vms { name } }"},
+        :as => :json
+      )
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects a user with bad credentials" do
+      user = User.create!(:name => "Alice", :userid => "Alice", :password => "letmein")
+
+      post(
+        "http://example.com/graphql",
+        :headers => {
+          "HTTP_AUTHORIZATION" => encode_credentials(user.userid, "keepmeout")
+        },
+        :params => {:query => "{ vms { name } }"},
+        :as => :json
+      )
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    def encode_credentials(user, password)
+      ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
+    end
+  end
+
+  it "rejects a user with no authentication" do
+    post(
+      "http://example.com/graphql",
+      :params => {:query => "{ vms { name } }"},
+      :as => :json
+    )
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   Kernel.srand config.seed
 
+  config.use_transactional_fixtures = true
+
   config.include ManageIQ::GraphQL::Engine.routes.url_helpers, :type => :routing
 
   # arbitrary gems may also be filtered via:


### PR DESCRIPTION
This adds basic authentication to the graphql API and requires that a user be authenticated for all requests.

There are a couple of reasons I chose basic auth.....the most salient being that AFAIK our current REST API requires basic auth as a prerequisite for issuing tokens anyway.

Once authenticated, the controller will set a `@current_user` variable, but I haven't attempted in this PR to hand that off to anything (presumable this would go into the context to be later evalated with RBAC).