### PR TITLE
Basic preloading capabilities with graphql-batch

### DIFF
--- a/lib/manageiq/graphql.rb
+++ b/lib/manageiq/graphql.rb
@@ -1,4 +1,7 @@
 require 'graphql'
+require 'graphql/batch'
+require 'graphql/preload'
+
 require 'manageiq/graphql/version'
 require 'manageiq/graphql/engine'
 require 'manageiq/graphql/schema'

--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -3,7 +3,10 @@ require 'manageiq/graphql/types/query'
 module ManageIQ
   module GraphQL
     Schema = ::GraphQL::Schema.define do
+      use ::GraphQL::Batch
+
       raise_definition_error true
+      enable_preloading
 
       query Types::Query
     end

--- a/lib/manageiq/graphql/types/vm.rb
+++ b/lib/manageiq/graphql/types/vm.rb
@@ -24,6 +24,8 @@ module ManageIQ
         field :cloud, !types.Boolean
         field :raw_power_state, !types.String
         field :service, Service, "The service object associated with this virtual machine" do
+          preload :direct_services
+
           resolve ->(object, args, ctx) {
             object.service
           }

--- a/manageiq-graphql.gemspec
+++ b/manageiq-graphql.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_runtime_dependency "graphql", "~> 1.7"
+  s.add_runtime_dependency "graphql-batch", "~> 0.3.8"
+  s.add_runtime_dependency "graphql-preload", "~> 1.0"
   s.add_runtime_dependency "rails", ">= 5.0", "< 5.1" # (In lieu of depending on ManageIQ core directly)
 
   s.add_development_dependency "rspec-rails", "~> 3.7"


### PR DESCRIPTION
This demonstrates the ability to be able to batch database queries across nodes with Shopify's graphql-batch gem (with a simple helper/AssociationLoader provided by graphql-preload to do something we'd just do ourselves here anyway)

Given the following query:

```
{
  vms {
    services {
      name
    }
  }
}
```

Before (and the way this is currently done in the REST API with its
synonymous REST call, I might add...):

```
D, [2017-11-30T10:30:39.272133 #17568] DEBUG -- :   Vm Load (45.7ms)  SELECT "vms".* FROM "vms" WHERE "vms"."type" IN ('Vm', 'ManageIQ::Providers::CloudManager::Vm', 'ManageIQ::Providers::InfraManager::Vm', 'VmServer', 'ManageIQ::Providers::Amazon::CloudManager::Vm', 'ManageIQ::Providers::Azure::CloudManager::Vm', 'ManageIQ::Providers::Google::CloudManager::Vm', 'ManageIQ::Providers::Openstack::CloudManager::Vm', 'ManageIQ::Providers::Vmware::CloudManager::Vm', 'VmXen', 'ManageIQ::Providers::Redhat::InfraManager::Vm', 'ManageIQ::Providers::Microsoft::InfraManager::Vm', 'ManageIQ::Providers::Vmware::InfraManager::Vm') AND "vms"."template" = $1  [["template", "f"]]
D, [2017-11-30T10:30:41.671159 #17568] DEBUG -- :   Vm Inst Including Associations (2381.9ms - 1107rows)
D, [2017-11-30T10:30:42.003938 #17568] DEBUG -- :   Service Load (305.9ms)  SELECT  "services".* FROM "services" INNER JOIN "service_resources" ON "services"."id" = "service_resources"."service_id" WHERE "service_resources"."resource_id" = $1 AND "service_resources"."resource_type" = $2 ORDER BY "services"."id" ASC LIMIT $3  [["resource_id", 20000000002021], ["resource_type", "VmOrTemplate"], ["LIMIT", 1]]
D, [2017-11-30T10:30:42.004317 #17568] DEBUG -- :   Service Inst Including Associations (0.0ms - 0rows)
D, [2017-11-30T10:30:42.008112 #17568] DEBUG -- :   Service Load (0.6ms)  SELECT  "services".* FROM "services" INNER JOIN "service_resources" ON "services"."id" = "service_resources"."service_id" WHERE "service_resources"."resource_id" = $1 AND "service_resources"."resource_type" = $2 ORDER BY "services"."id" ASC LIMIT $3  [["resource_id", 20000000002930], ["resource_type", "VmOrTemplate"], ["LIMIT", 1]]
D, [2017-11-30T10:30:42.008486 #17568] DEBUG -- :   Service Inst Including Associations (0.0ms - 0rows)
D, [2017-11-30T10:30:42.010491 #17568] DEBUG -- :   Service Load (0.6ms)  SELECT  "services".* FROM "services" INNER JOIN "service_resources" ON "services"."id" = "service_resources"."service_id" WHERE "service_resources"."resource_id" = $1 AND "service_resources"."resource_type" = $2 ORDER BY "services"."id" ASC LIMIT $3  [["resource_id", 20000000002022], ["resource_type", "VmOrTemplate"], ["LIMIT", 1]]
D, [2017-11-30T10:30:42.010845 #17568] DEBUG -- :   Service Inst Including Associations (0.0ms - 0rows)
D, [2017-11-30T10:30:42.012977 #17568] DEBUG -- :   Service Load (0.5ms)  SELECT  "services".* FROM "services" INNER JOIN "service_resources" ON "services"."id" = "service_resources"."service_id" WHERE "service_resources"."resource_id" = $1 AND "service_resources"."resource_type" = $2 ORDER BY "services"."id" ASC LIMIT $3  [["resource_id", 20000000002024], ["resource_type", "VmOrTemplate"], ["LIMIT", 1]]
...
...
...
```

After, with batching added:

```
D, [2017-11-30T14:53:14.764450 #26796] DEBUG -- :   Vm Load (32.7ms)  SELECT "vms".* FROM "vms" WHERE "vms"."type" IN ('Vm', 'ManageIQ::Providers::CloudManager::Vm', 'ManageIQ::Providers::InfraManager::Vm', 'VmServer', 'ManageIQ::Providers::Amazon::CloudManager::Vm', 'ManageIQ::Providers::Azure::CloudManager::Vm', 'ManageIQ::Providers::Google::CloudManager::Vm', 'ManageIQ::Providers::Openstack::CloudManager::Vm', 'ManageIQ::Providers::Vmware::CloudManager::Vm', 'VmXen', 'ManageIQ::Providers::Redhat::InfraManager::Vm', 'ManageIQ::Providers::Microsoft::InfraManager::Vm', 'ManageIQ::Providers::Vmware::InfraManager::Vm') AND "vms"."template" = $1  [["template", "f"]]
D, [2017-11-30T14:53:16.781808 #26796] DEBUG -- :   Vm Inst Including Associations (2012.4ms - 1107rows)
D, [2017-11-30T14:53:16.887047 #26796] DEBUG -- :   ServiceResource Load (5.5ms)  SELECT "service_resources".* FROM "service_resources" WHERE "service_resources"."resource_type" = $1 AND "service_resources"."resource_id" IN (20000000002021, 20000000002022, 20000000002024, 20000000002026, 20000000002025, 20000000002027, 20000000002030, 20000000002031, 20000000002029, 20000000002933, 20000000002210, 20000000002216, 20000000002217, 20000000002252, 20000000001457, 20000000002028, 20000000002034, 20000000002032, 20000000002033, 20000000002036, 20000000002035, 20000000002295, 20000000002037, 20000000002038, 20000000002039, 20000000002041, 20000000002042, 20000000002040, 20000000002044, 20000000002045, 20000000002047, 20000000002043, 20000000002049, 20000000002048, 20000000002051, 20000000002050, 20000000002253, 20000000002046, 20000000002350, 20000000002298, 20000000001474, 20000000002052, 20000000002053, 20000000002248, 20000000002054, 20000000002055, 20000000002058, 20000000000119, 20000000002056, 20000000002059, 20000000002553, 20000000001483, 20000000002299, 20000000002060, 20000000002061, 20000000002064, 20000000002066, 20000000002062, 20000000002063, 20000000001990, 20000000002065, 20000000002067, 20000000002069, 20000000002070, 20000000001986, 20000000001987, 20000000002068, 20000000002556, 20000000002546, 20000000002073, 20000000002072, 20000000002071, 20000000002414, 20000000001656, 20000000002218, 20000000001659, 20000000001524, 20000000001526, 20000000001658, 20000000002584, 20000000002419, 20000000002078, 20000000001525, 20000000002079, 20000000002583, 20000000002585, 20000000002586, 20000000002074, 20000000001531, 20000000002588, 20000000002075, 20000000002077, 20000000002076, 20000000002081, 20000000002215, 20000000002080, 20000000002083, 20000000002587, 20000000001988, 20000000001991, 20000000001989, 20000000002221, 20000000002423, 20000000002084, 20000000002085, 20000000001540, 20000000002219, 20000000002089, 20000000002441, 20000000002589, 20000000002410, 20000000002082, 20000000002086, 20000000002087, 20000000002088, 20000000001542, 20000000002591, 20000000002220, 20000000001543, 20000000001229, 20000000002224, 20000000002090, 20000000002092, 20000000002093, 20000000002590, 20000000002091, 20000000001377, 20000000002249, 20000000002250, 20000000002226, 20000000002394, 20000000001568, 20000000001567, 20000000002431, 20000000002415, 20000000002233, 20000000002222, 20000000002241, 20000000002223, 20000000002225, 20000000002228, 20000000002245, 20000000002246, 20000000002231, 20000000002229, 20000000002232, 20000000001657, 20000000002966, 20000000002965, 20000000002784, 20000000002964, 20000000002839, 20000000002838, 20000000002840, 20000000002429, 20000000002227, 20000000002437, 20000000002434, 20000000002975, 20000000002972, 20000000002236, 20000000002230, 20000000002237, 20000000002238, 20000000002974, 20000000002435, 20000000002234, 20000000002243, 20000000002235, 20000000002242, 20000000002239, 20000000002973, 20000000002976, 20000000002977, 20000000002247, 20000000002251, 20000000002189, 20000000002244, 20000000002200, 20000000002209, 20000000002201, 20000000002202, 20000000002203, 20000000002544, 20000000002205, 20000000002208, 20000000002204, 20000000002207, 20000000001484, 20000000002206, 20000000002325, 20000000002212, 20000000001985, 20000000001984, 20000000002213, 20000000002211, 20000000002214, 20000000001992, 20000000001999, 20000000002000, 20000000002001, 20000000002002, 20000000002003, 20000000002004, 20000000002009, 20000000002006, 20000000002007, 20000000002008, 20000000002005, 20000000002017, 20000000002010, 20000000002011, 20000000002012, 20000000002013, 20000000002014, 20000000002015, 20000000002016, 20000000002296, 20000000002259, 20000000002297, 20000000002256, 20000000002254, 20000000002255, 20000000002257, 20000000002258, 20000000002260, 20000000002261, 20000000002262, 20000000002263, 20000000002264, 20000000002265, 20000000002266, 20000000002267, 20000000002268, 20000000002269, 20000000002270, 20000000002271, 20000000002272, 20000000002273, 20000000002274, 20000000002275, 20000000002276, 20000000002277, 20000000002278, 20000000002280, 20000000002281, 20000000002283, 20000000002284, 20000000002285, 20000000002286, 20000000002287, 20000000002291, 20000000002282, 20000000002288, 20000000002289, 20000000002290, 20000000002292, 20000000002293, 20000000002850, 20000000002481, 20000000002430, 20000000002987, 20000000002387, 20000000002985, 20000000002495, 20000000002484, 20000000002482, 20000000002483, 20000000002986, 20000000002388, 20000000002389, 20000000002499, 20000000002436, 20000000002504, 20000000002501, 20000000002503, 20000000002861, 20000000002872, 20000000002347, 20000000002346, 20000000002338, 20000000002874, 20000000002440, 20000000002442, 20000000002878, 20000000002568, 20000000002569, 20000000002570, 20000000002577, 20000000002574, 20000000002578, 20000000002579, 20000000002573, 20000000002575, 20000000002571, 20000000002572, 20000000002576, 20000000002884, 20000000002896, 20000000002887, 20000000002888, 20000000002889, 20000000002899, 20000000002900, 20000000002894, 20000000002897, 20000000002895, 20000000002898, 20000000002890, 20000000002901, 20000000002891, 20000000002892, 20000000002893, 20000000002905, 20000000002907, 20000000003006, 20000000003009, 20000000003010, 20000000002906, 20000000003008, 20000000002913, 20000000002911, 20000000002912, 20000000002908, 20000000002909, 20000000002910, 20000000002393, 20000000002420, 20000000003046, 20000000003011, 20000000003007, 20000000003055, 20000000003056, 20000000003054, 20000000003073, 20000000003061, 20000000003069, 20000000003067, 20000000003063, 20000000003064, 20000000003065, 20000000003059, 20000000003060, 20000000003070, 20000000003075, 20000000003072, 20000000003071, 20000000003074, 20000000002391, 20000000002390, 20000000002392, 20000000002395, 20000000002502)  [["resource_type", "VmOrTemplate"]]
D, [2017-11-30T14:53:16.904346 #26796] DEBUG -- :   ServiceResource Inst Including Associations (16.4ms - 10rows)
...
...
```

This optimization is a 50% improvement over the previous call (and REST API), with caches warmed on a typical demo database. Keep in mind this is only one of many optimizations and preloads that this call *really* needs, so that's pretty striking.

Note that this is very basic stuff - custom batch loaders are really easy to add to handle some of our more complex and virtual associations in core (indeed, my first example of this I just added my own easy loader until I found the nice graphql-preload gem doing it for me, basically)

Closes #9 