### PR TITLE
Add Tagging API

### DIFF
--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -1,4 +1,5 @@
 require 'manageiq/graphql/types/query'
+require 'manageiq/graphql/types/mutation'
 
 module ManageIQ
   module GraphQL
@@ -9,6 +10,18 @@ module ManageIQ
       enable_preloading
 
       query Types::Query
+      mutation Types::Mutation
+
+      resolve_type ->(type, obj, ctx) {
+        # This is horrible. It's horrible because this is a PoC
+        # and it just needs to prove that one can resolve our AR models to
+        # GraphQL types. dealwithit.gif
+        if /Vm/ =~ obj.class.name
+          Types::Vm
+        elsif /Service/ =~ obj.class.name
+          Types::Service
+        end
+      }
     end
   end
 end

--- a/lib/manageiq/graphql/types/mutation.rb
+++ b/lib/manageiq/graphql/types/mutation.rb
@@ -1,0 +1,27 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      Mutation = ::GraphQL::ObjectType.define do
+        name 'Mutation'
+
+        field :addTags, Taggable do
+          # Note: This is an incredibly naive way of doing a mutation.
+          # Mutations should be implemented with object identification
+          # conforming to the Relay specification: https://facebook.github.io/relay/graphql/objectidentification.htm
+          description "Adds tags to a Taggable"
+          argument :taggableId, !types.ID
+          argument :taggableType, !types.String
+          argument :tagNames, !types[types.String]
+
+          resolve ->(object, args, ctx) {
+            # WARNING: This isn't actually safe, it's merely for PoC
+            klass = "::#{args[:taggableType]}".constantize
+            taggable = klass.find(args[:taggableId])
+            taggable.tag_add(args[:tagNames])
+            taggable.reload
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/mutation.rb
+++ b/lib/manageiq/graphql/types/mutation.rb
@@ -4,10 +4,11 @@ module ManageIQ
       Mutation = ::GraphQL::ObjectType.define do
         name 'Mutation'
 
+        # Note: These are incredibly naive ways of doing a mutation.
+        # Mutations should be implemented with object identification conforming
+        # to the Relay specification:
+        # https://facebook.github.io/relay/graphql/objectidentification.htm
         field :addTags, Taggable do
-          # Note: This is an incredibly naive way of doing a mutation.
-          # Mutations should be implemented with object identification
-          # conforming to the Relay specification: https://facebook.github.io/relay/graphql/objectidentification.htm
           description "Adds tags to a Taggable"
           argument :taggableId, !types.ID
           argument :taggableType, !types.String
@@ -18,6 +19,21 @@ module ManageIQ
             klass = "::#{args[:taggableType]}".constantize
             taggable = klass.find(args[:taggableId])
             taggable.tag_add(args[:tagNames])
+            taggable.reload
+          }
+        end
+
+        field :removeTags, Taggable do
+          description "Remove tags from a Taggable"
+          argument :taggableId, !types.ID
+          argument :taggableType, !types.String
+          argument :tagNames, !types[types.String]
+
+          resolve ->(object, args, ctx) {
+            # WARNING: This isn't actually safe, it's merely for PoC
+            klass = "::#{args[:taggableType]}".constantize
+            taggable = klass.find(args[:taggableId])
+            taggable.tag_remove(args[:tagNames])
             taggable.reload
           }
         end

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -1,4 +1,5 @@
 require 'manageiq/graphql/types/service'
+require 'manageiq/graphql/types/tag'
 require 'manageiq/graphql/types/vm'
 
 module ManageIQ
@@ -18,6 +19,12 @@ module ManageIQ
         field :services, !types[Types::Service], "List available services" do
           resolve -> (obj, args, ctx) {
             ::Service.all
+          }
+        end
+
+        field :tags, !types[Tag], "List available tags" do
+          resolve -> (obj, args, ctx) {
+            ::Tag.all
           }
         end
 

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -17,8 +17,14 @@ module ManageIQ
         end
 
         field :services, !types[Service], "List available services" do
+          argument :tags, types[types.String]
+
           resolve -> (obj, args, ctx) {
-            ::Service.all
+            if args[:tags]
+              ::Service.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
+            else
+              ::Service.all
+            end
           }
         end
 

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -16,7 +16,7 @@ module ManageIQ
           }
         end
 
-        field :services, !types[Types::Service], "List available services" do
+        field :services, !types[Service], "List available services" do
           resolve -> (obj, args, ctx) {
             ::Service.all
           }
@@ -36,7 +36,7 @@ module ManageIQ
           }
         end
 
-        field :vms, !types[Types::Vm], "List available virtual machines" do
+        field :vms, !types[Vm], "List available virtual machines" do
           resolve -> (obj, args, ctx) {
             ::Vm.all
           }

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -37,8 +37,14 @@ module ManageIQ
         end
 
         field :vms, !types[Vm], "List available virtual machines" do
+          argument :tags, types[types.String]
+
           resolve -> (obj, args, ctx) {
-            ::Vm.all
+            if args[:tags]
+              ::Vm.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
+            else
+              ::Vm.all
+            end
           }
         end
       end

--- a/lib/manageiq/graphql/types/service.rb
+++ b/lib/manageiq/graphql/types/service.rb
@@ -1,3 +1,5 @@
+require 'manageiq/graphql/types/taggable'
+
 module ManageIQ
   module GraphQL
     module Types

--- a/lib/manageiq/graphql/types/service.rb
+++ b/lib/manageiq/graphql/types/service.rb
@@ -4,6 +4,7 @@ module ManageIQ
       Service = ::GraphQL::ObjectType.define do
         name 'Service'
         description 'A Service is an item in a Service Catalog that can be requested.'
+        interfaces [Taggable]
 
         field :id, !types.ID, "The ID of the service"
         field :name, !types.String, "The name of the service"

--- a/lib/manageiq/graphql/types/tag.rb
+++ b/lib/manageiq/graphql/types/tag.rb
@@ -1,0 +1,12 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      Tag = ::GraphQL::ObjectType.define do
+        name 'Tag'
+        description 'Tags are descriptive terms defined by a ManageIQ user or the system used to categorize a resource.'
+
+        field :name, !types.String, "The name of the tag"
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/taggable.rb
+++ b/lib/manageiq/graphql/types/taggable.rb
@@ -1,0 +1,16 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      Taggable = ::GraphQL::InterfaceType.define do
+        name "Taggable"
+        field :tags, types[Tag], "A list of tags assigned with this taggable" do
+          preload :tags
+
+          resolve ->(object, args, ctx) {
+            object.tags
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/vm.rb
+++ b/lib/manageiq/graphql/types/vm.rb
@@ -30,6 +30,13 @@ module ManageIQ
             object.service
           }
         end
+        field :tags, types[Tag], "The tags associated with this virtual machine" do
+          preload :tags
+
+          resolve ->(object, args, ctx) {
+            object.tags
+          }
+        end
       end
     end
   end

--- a/lib/manageiq/graphql/types/vm.rb
+++ b/lib/manageiq/graphql/types/vm.rb
@@ -1,9 +1,12 @@
+require 'manageiq/graphql/types/taggable'
+
 module ManageIQ
   module GraphQL
     module Types
       Vm = ::GraphQL::ObjectType.define do
         name 'Vm'
         description 'A Virtual Machine is a software implementation of a system that functions similar to a physical machine. Virtual machines utilize the hardware infrastructure of a physical host, or a set of physical hosts, to provide a scalable and on-demand method of system provisioning.'
+        interfaces [Taggable]
 
         field :id, !types.ID, "The ID of the virtual machine"
         field :vendor, !types.String, "The virtual machine's vendor"
@@ -28,13 +31,6 @@ module ManageIQ
 
           resolve ->(object, args, ctx) {
             object.service
-          }
-        end
-        field :tags, types[Tag], "The tags associated with this virtual machine" do
-          preload :tags
-
-          resolve ->(object, args, ctx) {
-            object.tags
           }
         end
       end


### PR DESCRIPTION
Basic tagging, woo!

* Vms and Services now implement the same `Taggable` interface, demonstrating how to use an InterfaceType in GraphQL; here you can see that, as well as that you can query a Service's tags:

![](http://screenshots.chrisarcand.com/taovq.jpg)

* You can look up Vms and Services by tag(s), as well as list all known tags:

![](http://screenshots.chrisarcand.com/qoqrv.jpg)

* What's the point in being taggable if you can't change the tags? Mutations are now added to add/remove tags from *any* type that specifies itself as taggable:

![](http://screenshots.chrisarcand.com/0p90g.jpg)