### PR TITLE
Add existing token authentication from REST API

### DIFF
--- a/app/controllers/manageiq/graphql/graphql_controller.rb
+++ b/app/controllers/manageiq/graphql/graphql_controller.rb
@@ -3,13 +3,16 @@ require_dependency 'manageiq/graphql/application_controller'
 module ManageIQ
   module GraphQL
     class GraphQLController < ApplicationController
+      before_action :authenticate!
+
+      attr_reader :current_user
+
       def execute
         variables = ensure_hash(params[:variables])
         query = params[:query]
         operation_name = params[:operationName]
         context = {
-          # Query context goes here, for example:
-          # current_user: current_user,
+          current_user: current_user
         }
         result = Schema.execute(query, variables: variables, context: context, operation_name: operation_name)
         render json: result
@@ -36,6 +39,19 @@ module ManageIQ
           {}
         else
           raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
+        end
+      end
+
+      def authenticate!
+        token = request.headers['HTTP_X_AUTH_TOKEN']
+        api_token_mgr = ::Api::UserTokenService.new.token_mgr('api')
+
+        if token && api_token_mgr.token_valid?(token) && userid = api_token_mgr.token_get_info(token, :userid)
+          user = User.lookup_by_identity(userid)
+          User.current_user = user
+          @current_user = user
+        else
+          render :status => 401, :json => { :data => nil, :errors => [ { 'message' => 'Unauthorized' } ] }
         end
       end
 

--- a/lib/manageiq/graphql/engine.rb
+++ b/lib/manageiq/graphql/engine.rb
@@ -1,3 +1,5 @@
+require 'manageiq/graphql/rest_api_proxy'
+
 module ManageIQ
   module GraphQL
     class Engine < ::Rails::Engine
@@ -10,6 +12,10 @@ module ManageIQ
       isolate_namespace ManageIQ::GraphQL
 
       config.autoload_paths << root.join("lib").expand_path
+
+      initializer "graphql.add_rest_proxy" do |app|
+        app.middleware.use ManageIQ::GraphQL::RESTAPIProxy
+      end
 
       def vmdb_plugin?
         true

--- a/lib/manageiq/graphql/rest_api_proxy.rb
+++ b/lib/manageiq/graphql/rest_api_proxy.rb
@@ -1,0 +1,29 @@
+module ManageIQ
+  module GraphQL
+    ##
+    # A simple Rack Middlware for forwarding specific calls to the REST API
+    # This is intended to allow this API to use the REST API as a temporary
+    # crutch for things such as token authentication.
+    class RESTAPIProxy
+      PROXY_PATHS= [
+        'auth'
+      ].freeze
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        env['REQUEST_PATH'].gsub!("graphql", "api") if proxy?(env)
+        @app.call(env)
+      end
+
+      private
+
+      def proxy?(env)
+        # TODO: Incredibly naive, should take GraphQL engine's mount point in to account and not hardcode
+        !!PROXY_PATHS.detect { |path| /\/graphql\/#{path}\z/ =~ env['REQUEST_PATH'] }
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -1,5 +1,6 @@
 require 'manageiq/graphql/types/service'
 require 'manageiq/graphql/types/tag'
+require 'manageiq/graphql/types/user'
 require 'manageiq/graphql/types/vm'
 
 module ManageIQ
@@ -31,6 +32,12 @@ module ManageIQ
         field :tags, !types[Tag], "List available tags" do
           resolve -> (obj, args, ctx) {
             ::Tag.all
+          }
+        end
+
+        field :viewer, User, "The currently logged-in user" do
+          resolve -> (obj, args, ctx) {
+            ctx[:current_user]
           }
         end
 

--- a/lib/manageiq/graphql/types/user.rb
+++ b/lib/manageiq/graphql/types/user.rb
@@ -1,0 +1,14 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      User = ::GraphQL::ObjectType.define do
+        name 'User'
+        description 'In Identity Service, each user is associated with one or more tenants, and in Compute can be associated with roles, projects, or both.'
+
+        field :id, !types.ID
+        field :name, !types.String
+        field :email, !types.String
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds really basic authentication via the existing REST API tokens. With it, you can fetch a token via the `/auth` route (this part literally proxies to the REST API and doesn't use GraphQL because that part doesn't add any value to the PoC) and use it in a GraphQL query header to authenticate a user. This user is provided in the context argument passed to every GraphQL resolver.

Note that this locks down the API if you don't authenticate. So...

Fetch an API token:
```
$ curl --user admin:smartvm -i X GET -H "Accept: application/json" http://localhost:3000/graphql/auth
```

And put that token as your `HTTP_X_AUTH_TOKEN` header.

Note even further that the GraphiQL interface built in to the app in this PoC doesn't allow custom headers *by design*, unfortunately - this now requires you to use something like https://github.com/skevy/graphiql-app (available on all platforms)