### PR TITLE
Add basic VM power operations

### DIFF
--- a/lib/manageiq/graphql.rb
+++ b/lib/manageiq/graphql.rb
@@ -3,5 +3,9 @@ require 'graphql/batch'
 require 'graphql/preload'
 
 require 'manageiq/graphql/version'
+
+# TODO Automate/move these internal deps
+require 'manageiq/graphql/queue_service'
+
 require 'manageiq/graphql/engine'
 require 'manageiq/graphql/schema'

--- a/lib/manageiq/graphql/queue_service.rb
+++ b/lib/manageiq/graphql/queue_service.rb
@@ -1,0 +1,32 @@
+module ManageIQ
+  module GraphQL
+    class QueueService
+      def self.enqueue(*args)
+        new.enqueue(*args)
+      end
+
+      def initialize
+      end
+
+      def enqueue(object, description, options)
+        task_options = {
+          :action => description,
+          :userid => User.current_user.userid
+        }
+
+        queue_options = {
+          :class_name  => options[:class_name] || object.class.name,
+          :method_name => options[:method_name],
+          :instance_id => object.id,
+          :args        => options[:args] || [],
+          :role        => options[:role] || nil,
+        }
+
+        queue_options.merge!(options[:user]) if options.key?(:user)
+        queue_options[:zone] = object.my_zone if %w(ems_operations smartstate).include?(options[:role])
+
+        MiqTask.generic_action_with_callback(task_options, queue_options)
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/action_result_payload.rb
+++ b/lib/manageiq/graphql/types/action_result_payload.rb
@@ -1,0 +1,18 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      # TODO: This is basically just a simplied version of the current
+      # action result response in the REST API. It should probably be
+      # gone over and formalized a little better.
+      # It probably can't be used with Relay anyway.
+      ActionResultPayload = ::GraphQL::ObjectType.define do
+        name 'ActionResultPayload'
+        description "The result of an action taken on something"
+
+        field :success, !types.Boolean
+        field :message, types.String
+        field :task_id, types.Int
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/mutation.rb
+++ b/lib/manageiq/graphql/types/mutation.rb
@@ -1,3 +1,6 @@
+require 'manageiq/graphql/types/vm_power_operation'
+require 'manageiq/graphql/types/action_result_payload'
+
 module ManageIQ
   module GraphQL
     module Types
@@ -35,6 +38,38 @@ module ManageIQ
             taggable = klass.find(args[:taggableId])
             taggable.tag_remove(args[:tagNames])
             taggable.reload
+          }
+        end
+
+        # TODO: This is very PoC
+        field :performVmPowerOperation, ActionResultPayload do
+          name 'performVmPowerOperation'
+          description "Perform power operations on Virtual Machines"
+          argument :vm_id, !types.ID
+          argument :operation, VmPowerOperation
+
+          resolve ->(object, args, ctx) {
+            begin
+              vm = ::Vm.find(args[:vm_id])
+              vm = ::Rbac.filtered_object(vm)
+              description = "Performing #{args[:operation]} operation on VM id: #{vm.id}, name: '#{vm.name}'"
+
+              task_id = QueueService.enqueue(
+                vm,
+                description,
+                :method_name => args[:operation],
+                :role        => "ems_operations"
+              )
+
+              # TODO: ActionResultPayloads probably won't be a thing anyway, but even if they were to be
+              # this should be a proper object mapping to that type, not just OpenStruct....maybe.
+              # TODO: We shouldn't be rescuing all errors like we do in the REST API.
+              # We should be explicitly defining exceptional behavior from core and returning that, but
+              # properly raising our own faults.
+              OpenStruct.new(:success => true, :message => description, :task_id => task_id)
+            rescue StandardError => error
+              OpenStruct.new(:success => false, :message => error.to_s)
+            end
           }
         end
       end

--- a/lib/manageiq/graphql/types/vm_power_operation.rb
+++ b/lib/manageiq/graphql/types/vm_power_operation.rb
@@ -1,0 +1,15 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      VmPowerOperation = ::GraphQL::EnumType.define do
+        name 'VmPowerOperation'
+        description 'Power operations you can perform on virtual machines.'
+        value('START', 'Power on a virtual machine', :value => 'start')
+        value('STOP', 'Power off a virtual machine', :value => 'stop')
+        value('SUSPEND', 'Suspend a virtual machine', :value => 'suspend')
+        value('PAUSE', 'Pause a virtual machine', :value => 'pause')
+        value('RESET', 'Reset a virtual machine', :value => 'reset')
+      end
+    end
+  end
+end


### PR DESCRIPTION
![](http://screenshots.chrisarcand.com/pxhbm.jpg)
![](http://screenshots.chrisarcand.com/7g9c9.jpg)

Note that a lot of code here is very PoC:

* Minimal and very generic error handling
* Formalized a ActionResultPayload, which I basically ported from the REST API. I don't really like the format of this but again, not important right now.
* QueueService stuff which again, I basically just ported from the REST API and I don't know if I like the API for at all.

In other words, don't go building a bunch of stuff on top of this (even PoC work) as is *really* is just for showing basic VM power operation stuffs.

Closes #6 