### PR TITLE
Add hosts

### DIFF
--- a/lib/manageiq/graphql/types/host.rb
+++ b/lib/manageiq/graphql/types/host.rb
@@ -1,0 +1,48 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      Host = ::GraphQL::ObjectType.define do
+        name "Host"
+        description "A computer on which virtual machine monitor software is loaded."
+        interfaces [Taggable]
+
+        field :id, !types.ID, "The ID of the host"
+        field :name, !types.String, "The name of the host"
+        field :hostname, types.String
+        field :ipaddress, types.String
+        field :vmm_vendor, types.String
+        field :vmm_version, types.String
+        field :vmm_product, types.String
+        field :vmm_buildnumber, types.String
+        field :created_on, !types.String
+        field :updated_on, !types.String
+        field :guid, types.ID
+        field :user_assigned_os, types.String
+        field :power_state, types.String
+        field :smart, types.Int
+        field :last_perf_capture_on, types.String
+        field :uid_ems, types.ID
+        field :connection_state, types.String
+        field :ssh_permit_root_login, types.String
+        field :ems_ref_obj, types.String
+        field :admin_disabled, types.Boolean
+        field :service_tag, types.String
+        field :asset_tag, types.String
+        field :ipmi_address, types.String
+        field :mac_address, types.String
+        field :type, types.String
+        field :failover, types.Boolean
+        field :ems_ref, types.ID
+        field :hyperthreading, types.Boolean
+        field :next_available_vnc_port, types.Int
+        field :hypervisor_hostname, types.String
+        field :maintenance, types.Boolean
+        field :maintenance_reason, types.String
+
+        field :vms, types[Vm], "The virtual machines associated with this host" do
+          preload :vms
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a host type with top-level host and hosts fields. I've included all the host fields minus some obvious ones (I think all the foreign key columns), but if a smaller representative selection of fields is preferred I can reduce this down further. 

This provides the Taggable interface (hosts are taggable) and adds vms as a field of
hosts, so you can query the vms of a specified host or hosts.

AFAIK id, name and timestamps are the only fields guaranteed to be non-null.

I've tested that all fields of host can be retrieved as well as vms of hosts.

Here's a sample screenshot:

![screenshot from 2017-12-21 16-34-05](https://user-images.githubusercontent.com/1710874/34280523-004894fe-e66d-11e7-84d7-8ca180e43f54.png)

I haven't tested adding a tags argument yet, and there is still some documentation I need to add, but I thought I'd make a PR to get something out today, in case there's any more glaring feedback to take care of. I'm happy to add documentation here, or in a follow-up, whichever is preferred.