### PR TITLE
Add some tests

### DIFF
--- a/lib/manageiq/graphql.rb
+++ b/lib/manageiq/graphql.rb
@@ -1,7 +1,3 @@
-require 'graphql'
-require 'graphql/batch'
-require 'graphql/preload'
-
 require 'manageiq/graphql/version'
 
 # TODO Automate/move these internal deps

--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -1,3 +1,6 @@
+require 'graphql'
+require 'graphql/batch'
+require 'graphql/preload'
 require 'manageiq/graphql/types/query'
 require 'manageiq/graphql/types/mutation'
 

--- a/spec/integration/viewer_spec.rb
+++ b/spec/integration/viewer_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "viewer" do
+  context "when authenticated" do
+    let(:user) { FactoryGirl.create(:user, :name => "Alice") }
+
+    it "will respond with information about the authenticated user" do
+      post(
+        "/graphql",
+        :headers => {"HTTP_X_AUTH_TOKEN" => token},
+        :params => {:query => "{ viewer { name } }"},
+        :as => :json
+      )
+
+      expected = {
+        "data" => {
+          "viewer" => {
+            "name" => "Alice"
+          }
+        }
+      }
+      expect(response.parsed_body).to eq(expected)
+    end
+  end
+end

--- a/spec/integration/vms_spec.rb
+++ b/spec/integration/vms_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Vm queries" do
+  describe "'vms' field" do
+    it "will return the specified fields of all vms" do
+      FactoryGirl.create(:vm, :name => "Alice's VM")
+
+      post(
+        "/graphql",
+        :headers => {"HTTP_X_AUTH_TOKEN" => token},
+        :params  => {:query => "{ vms { name } }"},
+        :as      => :json
+
+      )
+
+      expect(response.parsed_body).to eq("data" => {"vms" => [{"name" => "Alice's VM"}]})
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,17 @@
+# Load the ManageIQ environment
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path("../manageiq/config/environment", __FILE__)
+
+require "manageiq/graphql"
+require 'rspec/rails'
+
+RSpec.configure do |config|
+  config.use_transactional_fixtures = true
+  config.infer_spec_type_from_file_location!
+  config.filter_rails_from_backtrace!
+  config.expose_dsl_globally = true
+
+  config.include ManageIQ::GraphQL::Engine.routes.url_helpers, :type => :routing
+end
+
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,8 @@ RSpec.configure do |config|
   config.expose_dsl_globally = true
 
   config.include ManageIQ::GraphQL::Engine.routes.url_helpers, :type => :routing
+
+  config.include_context "integration test setup", :type => :request
 end
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }

--- a/spec/routing/graphql_routes_spec.rb
+++ b/spec/routing/graphql_routes_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe "GraphQL endpoint" do
   describe "#endpoint" do
     it "returns /graphql" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,6 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-ENV['RAILS_ENV'] ||= 'test'
-
-# Load the ManageIQ environment
-require File.expand_path("../manageiq/config/environment", __FILE__)
-
-require 'rspec/rails'
+require "manageiq/graphql/schema"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -23,15 +18,8 @@ RSpec.configure do |config|
   config.default_formatter = "doc" if config.files_to_run.one?
   config.order = :random
 
-  config.infer_spec_type_from_file_location!
-  config.filter_rails_from_backtrace!
   Kernel.srand config.seed
-
-  config.include ManageIQ::GraphQL::Engine.routes.url_helpers, :type => :routing
 
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
-
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,3 +23,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Dir["./spec/support/**/*.rb"].each { |f| require f }

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,0 +1,17 @@
+module ManageIQ
+  module GraphQL
+    module CustomMatchers
+      extend RSpec::Matchers::DSL
+
+      matcher :resolve do |object, args = nil, context = nil|
+        match do |field|
+          field.resolve(object, args, context) == @expected
+        end
+
+        chain :to do |expected|
+          @expected = expected
+        end
+      end
+    end
+  end
+end

--- a/spec/support/integration_test_setup.rb
+++ b/spec/support/integration_test_setup.rb
@@ -1,0 +1,12 @@
+RSpec.shared_context "integration test setup" do
+  let(:server) { FactoryGirl.create(:miq_server) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
+  let(:token) { token_service.generate_token(user.userid, "api") }
+
+  before do
+    Tenant.create!(:use_config_for_attributes => false)
+    allow(MiqServer).to receive(:my_guid).and_return(server.guid)
+    MiqServer.my_server_clear_cache
+  end
+end

--- a/spec/unit/date_time_spec.rb
+++ b/spec/unit/date_time_spec.rb
@@ -1,0 +1,22 @@
+require "active_support/time"
+Time.zone ||= "UTC"
+
+RSpec.describe ManageIQ::GraphQL::Types::DateTime do
+  let(:context) { {} }
+
+  example "coercing output" do
+    time = Time.utc(2018, 1, 1, 0, 0, 0)
+
+    actual = described_class.coerce_result(time, context)
+
+    expect(actual).to eq("2018-01-01T00:00:00Z")
+  end
+
+  example "coercing input" do
+    time = "2018-01-01T00:00:00Z"
+
+    actual = described_class.coerce_input(time, context)
+
+    expect(actual).to eq(Time.utc(2018, 1, 1, 0, 0, 0))
+  end
+end

--- a/spec/unit/taggable_spec.rb
+++ b/spec/unit/taggable_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe ManageIQ::GraphQL::Types::Taggable do
+  include ManageIQ::GraphQL::CustomMatchers
+
+  describe "the tags field" do
+    let(:tags_field) { described_class.fields["tags"] }
+    let(:tag) { instance_double("::Tag") }
+    let(:object) { instance_double("::Vm", :tags => [tag]) }
+
+    it "resolves the tags for a given object" do
+      expect(tags_field).to resolve(object).to([tag])
+    end
+  end
+end


### PR DESCRIPTION
I've mainly used http://graphql-ruby.org/schema/testing as a guide for testing here. In summary, it provides three broad approaches, which I'll copy here for convenience:

1. Don’t test the schema, test other objects instead
2. Test schema elements (types, fields) in isolation
3. Execute GraphQL queries and test the result

I think that (1) is maybe not as well suited - it sort of assumes that you're developing a conventional app where you can start pulling out objects to decorate your models, and I think we probably won't want to do that.

I've provided some examples here of (2) and (3) type tests, and I'll comment more inline with the code on thoughts there. I've also provided a full-stack integration test, which I think will be useful when testing behavior that's coupled to the HTTP request (authentication, etc..). I didn't want to get too coupled with the way authentication is presently done, but rather provide an example that was illustrative of a good use case for a test of this size.

In general I like the idea of having small/medium/large tests to choose from - it requires more thought about where you want to test something and why (rather than, say, testing everything through the request cycle), but I see that mainly as a good thing.

I've also, as a preliminary step, done a little bit of restructuring to the plugin and the spec helpers with the following aim in mind: I'd like to be able to execute "small" tests without having to wait for Rails to load and boot. I'm OK with pulling this out of here if the way I have gone about it is problematic in ways that I haven't foreseen. But I do want to stress that I think this is a worthwhile goal if it is an easy win at this stage, as decoupling later can be damn near impossible.