### PR TITLE
Split test dependencies in to spec_helper and manageiq_helper

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
---require manageiq/spec/spec_helper
 --require spec_helper
 --color
 --order random

--- a/.rspec_ci
+++ b/.rspec_ci
@@ -1,4 +1,3 @@
---require manageiq/spec/spec_helper
 --require spec_helper
 --color
 --order random

--- a/lib/manageiq/graphql/engine.rb
+++ b/lib/manageiq/graphql/engine.rb
@@ -1,3 +1,5 @@
+require 'rails'
+require 'action_controller/railtie'
 require 'manageiq/graphql/rest_api_proxy'
 
 module ManageIQ

--- a/spec/integration/authentication_spec.rb
+++ b/spec/integration/authentication_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require "manageiq_helper"
 
 RSpec.describe "authentication" do
   describe "basic authentication" do

--- a/spec/integration/vms_spec.rb
+++ b/spec/integration/vms_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require "manageiq_helper"
 
 RSpec.describe "Vm queries" do
   describe "'vms' field" do

--- a/spec/manageiq_helper.rb
+++ b/spec/manageiq_helper.rb
@@ -1,10 +1,15 @@
+#
+# ManageIQ and Rails configuration
+# For general RSpec configuration, see spec_helper.rb
+# Require this file in every spec file that requires ManageIQ to run
+#
+
 # Load the ManageIQ environment
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path("../manageiq/config/environment", __FILE__)
 
-require "manageiq/graphql"
+# Configure rspec-rails
 require 'rspec/rails'
-
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
@@ -16,4 +21,5 @@ RSpec.configure do |config|
   config.include_context "integration test setup", :type => :request
 end
 
+# Load test helpers from ManageIQ
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }

--- a/spec/routing/graphql_routes_spec.rb
+++ b/spec/routing/graphql_routes_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require "manageiq_helper"
 
 RSpec.describe "GraphQL endpoint" do
   describe "#endpoint" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,32 +1,17 @@
+#
+# General RSpec configuration
+# For Rails or ManageIQ-specific configuration, see manageiq_helper.rb
+# This file is automatically required for all specs
+#
+
 if ENV['CI']
   require 'simplecov'
   SimpleCov.start
 end
 
-# See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-
-require "manageiq/graphql/schema"
-
 RSpec.configure do |config|
-  config.expect_with :rspec do |expectations|
-    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-  end
-
-  config.mock_with :rspec do |mocks|
-    mocks.verify_partial_doubles = true
-  end
-
-  config.shared_context_metadata_behavior = :apply_to_host_groups
-  config.filter_run_when_matching :focus
-  config.example_status_persistence_file_path = "spec/examples.txt"
-  config.disable_monkey_patching!
-  config.default_formatter = "doc" if config.files_to_run.one?
-  config.order = :random
-
-  Kernel.srand config.seed
-
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
 end
 
 Dir["./spec/support/**/*.rb"].each { |f| require f }
+
+require 'manageiq-graphql'


### PR DESCRIPTION
In this project we're trying to manage the actual intended difference between spec_helper and rails_helper to have better load times for TDD. The awkward part here is that this project is very different from all ManageIQ plugins we're built so far:

* This project is not entirely dependent upon Rails/ManageIQ - it's not just adding ActiveRecord models or separate Rails controllers to ManageIQ - it's an entire API built from a different dependency (the GraphQL schema built with graphql-ruby).

* But this project *is* dependent on Rails - it uses a *tiny* bit of Rails (Rails::Engine and ActionDispatch) and of course requires ManageIQ for its resolvers containing business logic; we also want to utilize Rails' code reloading, which requires you to use autoloading, which requires you to <long list of things that eventually leads to> using Rails :)

**Tests that do not require ManageIQ to be loaded to run are much, much faster and able to provide true TDD with next to no load times if you *only* load ManageIQ when necessary.**

Therefore, we make a new distinction here:

* spec_helper contains *general* spec configuration and does not load ManageIQ. The engine itself loads the direct dependencies on Rails that it needs to load (ActionDispatch, really). This spec_helper is automatically required on EVERY test in the project.

* manageiq_helper contains loading of the ManageIQ codebase and rspec-rails Because 'rails_helper' is a bit of a misnomer (since this helper really is about ManageIQ, the Rails application, more so than loading Rails) we just rename it to manageiq_helper, as that's the thing we're really needing help with! This file should be required in every spec file that needs ManageIQ core to function, and *not* included in ones that don't.

This distinction makes a lot of sense if you think about it - normal projects have their business logic set up (spec_helper) and separately when Rails is needed (rails_helper). Because this project is an engine, it loads Rails (spec_helper) and separately when *the application* is needed (manageiq_helper).

Although other projects might not reap *as much* benefit from this method, depending on how this goes this could be a great model for improvement in all the other ManageIQ plugins.