### PR TITLE
GraphQL should have its own settings

### DIFF
--- a/app/controllers/manageiq/graphql/application_controller.rb
+++ b/app/controllers/manageiq/graphql/application_controller.rb
@@ -23,7 +23,7 @@ module ManageIQ
             password,
             request,
             :require_user => true,
-            :timeout      => ::Settings.api.authentication_timeout.to_i_with_method
+            :timeout      => ::Settings.graphql_api.authentication_timeout.to_i_with_method
           )
         end
         User.current_user = @current_user

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,3 @@
+---
+:graphql_api:
+  :authentication_timeout: 30.seconds


### PR DESCRIPTION
The implementation for basic authentication is currently borrowing a
value from the REST API's settings - it should have its own.

Resolves https://www.pivotaltracker.com/story/show/154342150