### PR TITLE
Remove V2 designation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ManageIQ/api?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Translate](https://img.shields.io/badge/translate-zanata-blue.svg)](https://translate.zanata.org/zanata/project/view/manageiq-graphql)
 
-The [GraphQL](http://graphql.org/) V2 API for [ManageIQ](https://github.com/ManageIQ/manageiq)
+The [GraphQL](http://graphql.org/) API for [ManageIQ](https://github.com/ManageIQ/manageiq)
 
 **Note: This project is currently in early alpha**
 

--- a/manageiq-graphql.gemspec
+++ b/manageiq-graphql.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ["ManageIQ Authors"]
   s.homepage    = "https://github.com/ManageIQ/manageiq-graphql"
   s.summary     = "The GraphQL API for ManageIQ"
-  s.description = "This project includes the Rails engine powering the GraphQL V2 API for ManageIQ - https://github.com/ManageIQ/manageiq"
+  s.description = "This project includes the Rails engine powering the GraphQL API for ManageIQ - https://github.com/ManageIQ/manageiq"
   s.license     = "Apache-2.0"
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]


### PR DESCRIPTION
After some discussion, it was decided we'll remove the 'V2' designation from this API and just refer to them as 'REST API' and 'GraphQL API' respectively.