### PR TITLE
Run rubocop --auto-correct on project

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,3 +1,6 @@
 GlobalVars:
   AllowedVariables:
   - $api_log
+Style/Lambda:
+  Exclude:
+  - lib/manageiq/graphql/**/*

--- a/app/controllers/manageiq/graphql/application_controller.rb
+++ b/app/controllers/manageiq/graphql/application_controller.rb
@@ -12,7 +12,7 @@ module ManageIQ
       def authenticate!
         return if try_authenticate_with_http_basic || try_authenticate_with_http_token
         headers["WWW-Authenticate"] = 'Basic realm="Application"'
-        render :status => 401, :json => { :data => nil, :errors => [ { 'message' => 'Unauthorized' } ] }
+        render :status => 401, :json => { :data => nil, :errors => [{ 'message' => 'Unauthorized' }] }
       end
 
       def try_authenticate_with_http_basic

--- a/app/controllers/manageiq/graphql/graphql_controller.rb
+++ b/app/controllers/manageiq/graphql/graphql_controller.rb
@@ -9,10 +9,10 @@ module ManageIQ
         query = params[:query]
         operation_name = params[:operationName]
         context = {
-          current_user: current_user
+          :current_user => current_user
         }
-        result = Schema.execute(query, variables: variables, context: context, operation_name: operation_name)
-        render json: result
+        result = Schema.execute(query, :variables => variables, :context => context, :operation_name => operation_name)
+        render :json => result
       end
 
       private

--- a/bin/rspec
+++ b/bin/rspec
@@ -12,7 +12,7 @@ load(bundle_binstub) if File.file?(bundle_binstub)
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+                                           Pathname.new(__FILE__).realpath)
 
 require "rubygems"
 require "bundler/setup"

--- a/bin/setup
+++ b/bin/setup
@@ -11,7 +11,7 @@ gem_root = Pathname.new(__dir__).join("..")
 
 unless gem_root.join("spec/manageiq").exist?
   puts "== Cloning manageiq sample app =="
-  system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
+  system("git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq")
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 ManageIQ::GraphQL::Engine.routes.draw do
-  root :to => 'graphql#execute', :as => :endpoint, via: :post
+  root :to => 'graphql#execute', :as => :endpoint, :via => :post
 end
 
 Rails.application.routes.draw do

--- a/lib/manageiq/graphql/engine.rb
+++ b/lib/manageiq/graphql/engine.rb
@@ -24,7 +24,7 @@ module ManageIQ
       config.autoload_paths << root.join('lib').to_s
 
       initializer "graphql.add_rest_proxy" do |app|
-        app.middleware.use ManageIQ::GraphQL::RESTAPIProxy
+        app.middleware.use(ManageIQ::GraphQL::RESTAPIProxy)
       end
 
       def vmdb_plugin?

--- a/lib/manageiq/graphql/rest_api_proxy.rb
+++ b/lib/manageiq/graphql/rest_api_proxy.rb
@@ -5,7 +5,7 @@ module ManageIQ
     # This is intended to allow this API to use the REST API as a temporary
     # crutch for things such as token authentication.
     class RESTAPIProxy
-      PROXY_PATHS= [
+      PROXY_PATHS = [
         'auth'
       ].freeze
 

--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -13,7 +13,7 @@ module ManageIQ
       query Types::Query
       mutation Types::Mutation
 
-      resolve_type ->(type, obj, ctx) {
+      resolve_type ->(_type, obj, _ctx) {
         # This is horrible. It's horrible because this is a PoC
         # and it just needs to prove that one can resolve our AR models to
         # GraphQL types. dealwithit.gif

--- a/lib/manageiq/graphql/types/date_time.rb
+++ b/lib/manageiq/graphql/types/date_time.rb
@@ -5,8 +5,8 @@ module ManageIQ
         name "DateTime"
         description "An ISO-8601 encoded UTC date string."
 
-        coerce_input ->(value, ctx) { Time.zone.parse(value) }
-        coerce_result ->(value, ctx) { value.utc.iso8601 }
+        coerce_input ->(value, _ctx) { Time.zone.parse(value) }
+        coerce_result ->(value, _ctx) { value.utc.iso8601 }
       end
     end
   end

--- a/lib/manageiq/graphql/types/mutation.rb
+++ b/lib/manageiq/graphql/types/mutation.rb
@@ -14,7 +14,7 @@ module ManageIQ
           argument :taggableType, !types.String
           argument :tagNames, !types[types.String]
 
-          resolve ->(object, args, ctx) {
+          resolve ->(_object, args, _ctx) {
             # WARNING: This isn't actually safe, it's merely for PoC
             klass = "::#{args[:taggableType]}".constantize
             taggable = klass.find(args[:taggableId])
@@ -29,7 +29,7 @@ module ManageIQ
           argument :taggableType, !types.String
           argument :tagNames, !types[types.String]
 
-          resolve ->(object, args, ctx) {
+          resolve ->(_object, args, _ctx) {
             # WARNING: This isn't actually safe, it's merely for PoC
             klass = "::#{args[:taggableType]}".constantize
             taggable = klass.find(args[:taggableId])
@@ -45,7 +45,7 @@ module ManageIQ
           argument :vm_id, !types.ID
           argument :operation, VmPowerOperation
 
-          resolve ->(object, args, ctx) {
+          resolve ->(_object, args, _ctx) {
             begin
               vm = ::Vm.find(args[:vm_id])
               vm = ::Rbac.filtered_object(vm)

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -7,7 +7,7 @@ module ManageIQ
         field :host, Host, "Look up a host by its ID" do
           argument :id, types.ID
 
-          resolve -> (obj, args, ctx) {
+          resolve ->(_obj, args, _ctx) {
             host = ::Host.find(args[:id])
             ::Rbac.filtered_object(host)
           }
@@ -16,7 +16,7 @@ module ManageIQ
         field :hosts, !types[Host], "List available hosts" do
           argument :tags, types[types.String]
 
-          resolve -> (obj, args, ctx) {
+          resolve ->(_obj, args, _ctx) {
             hosts = if args[:tags]
                       ::Host.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
                     else
@@ -29,7 +29,7 @@ module ManageIQ
         field :service, Service, "Look up a service by its ID" do
           argument :id, types.ID
 
-          resolve -> (obj, args, ctx) {
+          resolve ->(_obj, args, _ctx) {
             service = ::Service.find(args[:id])
             ::Rbac.filtered_object(service)
           }
@@ -38,7 +38,7 @@ module ManageIQ
         field :services, !types[Service], "List available services" do
           argument :tags, types[types.String]
 
-          resolve -> (obj, args, ctx) {
+          resolve ->(_obj, args, _ctx) {
             services = if args[:tags]
                          ::Service.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
                        else
@@ -49,13 +49,13 @@ module ManageIQ
         end
 
         field :tags, !types[Tag], "List available tags" do
-          resolve -> (obj, args, ctx) {
+          resolve ->(_obj, _args, _ctx) {
             ::Rbac.filtered(::Tag.all)
           }
         end
 
         field :viewer, User, "The currently logged-in user" do
-          resolve -> (obj, args, ctx) {
+          resolve ->(_obj, _args, ctx) {
             ctx[:current_user]
           }
         end
@@ -63,7 +63,7 @@ module ManageIQ
         field :vm, Vm, "Look up a virtual machine by its ID" do
           argument :id, types.ID
 
-          resolve -> (obj, args, ctx) {
+          resolve ->(_obj, args, _ctx) {
             vm = ::Vm.find(args[:id])
             ::Rbac.filtered_object(vm)
           }
@@ -72,7 +72,7 @@ module ManageIQ
         field :vms, !types[Vm], "List available virtual machines" do
           argument :tags, types[types.String]
 
-          resolve -> (obj, args, ctx) {
+          resolve ->(_obj, args, _ctx) {
             vms = if args[:tags]
                     ::Vm.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
                   else

--- a/lib/manageiq/graphql/types/service.rb
+++ b/lib/manageiq/graphql/types/service.rb
@@ -15,7 +15,7 @@ module ManageIQ
         field :retired, !types.Boolean, "A true/false value as to whether the service is retired or not"
         field :retires_on, DateTime, "A string representation of the date this service is to be retired"
         field :vms, types[Vm], "The virtual machines associated with this service" do
-          resolve ->(object, args, ctx) {
+          resolve ->(object, _args, _ctx) {
             object.vms
           }
         end

--- a/lib/manageiq/graphql/types/taggable.rb
+++ b/lib/manageiq/graphql/types/taggable.rb
@@ -6,7 +6,7 @@ module ManageIQ
         field :tags, types[Tag], "A list of tags assigned with this taggable" do
           preload :tags
 
-          resolve ->(object, args, ctx) {
+          resolve ->(object, _args, _ctx) {
             object.tags
           }
         end

--- a/lib/manageiq/graphql/types/vm.rb
+++ b/lib/manageiq/graphql/types/vm.rb
@@ -26,7 +26,7 @@ module ManageIQ
         field :service, Service, "The service object associated with this virtual machine" do
           preload :direct_services
 
-          resolve ->(object, args, ctx) {
+          resolve ->(object, _args, _ctx) {
             object.service
           }
         end

--- a/lib/manageiq/graphql/version.rb
+++ b/lib/manageiq/graphql/version.rb
@@ -1,5 +1,5 @@
 module ManageIQ
   module GraphQL
-    VERSION = '0.1.0'
+    VERSION = '0.1.0'.freeze
   end
 end

--- a/manageiq-graphql.gemspec
+++ b/manageiq-graphql.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path("../lib", __FILE__)
+$:.push(File.expand_path("../lib", __FILE__))
 
 # Maintain your gem's version:
 require "manageiq/graphql/version"
@@ -15,13 +15,13 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_runtime_dependency "graphql", "~> 1.7"
-  s.add_runtime_dependency "graphql-batch", "~> 0.3.8"
-  s.add_runtime_dependency "graphql-preload", "~> 1.0"
+  s.add_runtime_dependency("graphql", "~> 1.7")
+  s.add_runtime_dependency("graphql-batch", "~> 0.3.8")
+  s.add_runtime_dependency("graphql-preload", "~> 1.0")
 
-  s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
-  s.add_development_dependency "rspec-rails", "~> 3.7"
-  s.add_development_dependency "simplecov"
-  s.add_development_dependency "spring"
-  s.add_development_dependency "spring-commands-rspec"
+  s.add_development_dependency("codeclimate-test-reporter", "~> 1.0.0")
+  s.add_development_dependency("rspec-rails", "~> 3.7")
+  s.add_development_dependency("simplecov")
+  s.add_development_dependency("spring")
+  s.add_development_dependency("spring-commands-rspec")
 end

--- a/spec/integration/authentication_spec.rb
+++ b/spec/integration/authentication_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe "authentication" do
       post(
         "/graphql",
         :headers => {"Authorization" => encode_credentials(user.userid, user.password) },
-        :params => {:query => "{ viewer { name } }"},
-        :as => :json
+        :params  => {:query => "{ viewer { name } }"},
+        :as      => :json
       )
 
       expected = {
@@ -37,12 +37,12 @@ RSpec.describe "authentication" do
       post(
         "/graphql",
         :headers => {"Authorization" => encode_credentials(user.userid, "hunter2") },
-        :params => {:query => "{ viewer { name } }"},
-        :as => :json
+        :params  => {:query => "{ viewer { name } }"},
+        :as      => :json
       )
 
       expected = {
-        "data" => nil,
+        "data"   => nil,
         "errors" => [
           {"message" => "Unauthorized"}
         ]
@@ -63,8 +63,8 @@ RSpec.describe "authentication" do
       post(
         "/graphql",
         :headers => {"HTTP_X_AUTH_TOKEN" => token},
-        :params => {:query => "{ viewer { name } }"},
-        :as => :json
+        :params  => {:query => "{ viewer { name } }"},
+        :as      => :json
       )
 
       expected = {
@@ -83,11 +83,11 @@ RSpec.describe "authentication" do
       post(
         "/graphql",
         :params => {:query => "{ viewer { name } }"},
-        :as => :json
+        :as     => :json
       )
 
       expected = {
-        "data" => nil,
+        "data"   => nil,
         "errors" => [
           {"message" => "Unauthorized"}
         ]

--- a/spec/integration/vms_spec.rb
+++ b/spec/integration/vms_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe "Vm queries" do
         :headers => {"HTTP_X_AUTH_TOKEN" => token},
         :params  => {:query => "{ vms { name } }"},
         :as      => :json
-
       )
 
       expect(response.parsed_body).to eq("data" => {"vms" => [{"name" => "Alice's VM"}]})


### PR DESCRIPTION
Though I do not enjoy bowing down to the tyrant that is rubocop, I considered that it might be good to do this early on in the repository's history. There are some remaining offenses leftover which I did not attempt to fix by hand - I suspect some of them we may want to debate over. Here they are in full:

```
bundle exec rubocop --format emacs /home/tim/src/manageiq-graphql/
/home/tim/src/manageiq-graphql/Rakefile:9:1: W: Lint/HandleExceptions: Do not suppress exceptions.
/home/tim/src/manageiq-graphql/manageiq-graphql.gemspec:1:1: C: Style/SpecialGlobalVars: Prefer `$LOAD_PATH` over `$:`.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/vm.rb:29:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/mutation.rb:17:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/mutation.rb:32:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/mutation.rb:48:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/service.rb:18:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/host.rb:17:28: C: Style/DateTime: Prefer Date or Time over DateTime.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/host.rb:18:28: C: Style/DateTime: Prefer Date or Time over DateTime.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/query.rb:10:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/query.rb:19:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/query.rb:32:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/query.rb:41:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/query.rb:52:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/query.rb:58:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/query.rb:66:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/query.rb:75:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/types/taggable.rb:9:19: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq/graphql/schema.rb:16:20: C: Style/Lambda: Use the `lambda` method for multiline lambdas.
/home/tim/src/manageiq-graphql/lib/manageiq-graphql.rb:1:1: C: Naming/FileName: The name of this source file (`manageiq-graphql.rb`) should use snake_case.
/home/tim/src/manageiq-graphql/bundler.d/Gemfile.dev.rb:1:1: C: Naming/FileName: The name of this source file (`Gemfile.dev.rb`) should use snake_case.
/home/tim/src/manageiq-graphql/spec/manageiq_helper.rb:22:5: C: Rails/FilePath: Please use `Rails.root.join('path', 'to')` instead.
/home/tim/src/manageiq-graphql/app/controllers/manageiq/graphql/application_controller.rb:40:65: W: Lint/AssignmentInCondition: Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
```

The main thing that sticks out is the stabby lambda style - @chrisarcand do you consider that part of graphql-ruby's DSL (and hence configure to ignore), or something to fix? Marking as WIP for now