### PR TITLE
Add integration macros

### DIFF
--- a/spec/integration/authentication_spec.rb
+++ b/spec/integration/authentication_spec.rb
@@ -1,80 +1,68 @@
 require "manageiq_helper"
 
 RSpec.describe "authentication" do
-  let(:server) { FactoryGirl.create(:miq_server) }
-  let(:user) { FactoryGirl.create(:user) }
-  let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
-  let(:token) { token_service.generate_token(user.userid, "api") }
-
-  before do
-    Tenant.create!(:use_config_for_attributes => false)
-    allow(MiqServer).to receive(:my_guid).and_return(server.guid)
-    MiqServer.my_server_clear_cache
-  end
-
   describe "basic authentication" do
-    let(:user) { FactoryGirl.create(:user, :name => "Alice", :userid => "Alice", :password => "alicepassword") }
+    as_user(:name => 'Alice', :password => 'alicepassword') do
+      it "will authenticate a user with good credentials" do
+        post(
+          "/graphql",
+          :headers => {"Authorization" => encode_basic_auth_credentials(user.userid, user.password) },
+          :params  => {:query => "{ viewer { name } }"},
+          :as      => :json
+        )
 
-    it "will authenticate a user with good credentials" do
-      post(
-        "/graphql",
-        :headers => {"Authorization" => encode_credentials(user.userid, user.password) },
-        :params  => {:query => "{ viewer { name } }"},
-        :as      => :json
-      )
-
-      expected = {
-        "data" => {
-          "viewer" => {
-            "name" => "Alice"
+        expected = {
+          "data" => {
+            "viewer" => {
+              "name" => "Alice"
+            }
           }
         }
-      }
-      expect(response.parsed_body).to eq(expected)
-    end
+        expect(response.parsed_body).to eq(expected)
+      end
 
-    it "responds with an error message and a challenge for a user with bad credentials" do
-      post(
-        "/graphql",
-        :headers => {"Authorization" => encode_credentials(user.userid, "hunter2") },
-        :params  => {:query => "{ viewer { name } }"},
-        :as      => :json
-      )
+      it "responds with an error message and a challenge for a user with bad credentials" do
+        post(
+          "/graphql",
+          :headers => {"Authorization" => encode_basic_auth_credentials(user.userid, "hunter2") },
+          :params  => {:query => "{ viewer { name } }"},
+          :as      => :json
+        )
 
-      expected = {
-        "data"   => nil,
-        "errors" => [
-          {"message" => "Unauthorized"}
-        ]
-      }
-      expect(response.parsed_body).to eq(expected)
-      expect(response.headers["WWW-Authenticate"]).to eq('Basic realm="Application"')
-    end
-
-    def encode_credentials(user, password)
-      ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
+        expected = {
+          "data"   => nil,
+          "errors" => [
+            {"message" => "Unauthorized"}
+          ]
+        }
+        expect(response.parsed_body).to eq(expected)
+        expect(response.headers["WWW-Authenticate"]).to eq('Basic realm="Application"')
+      end
     end
   end
 
   describe "token authentication" do
-    let(:user) { FactoryGirl.create(:user, :name => "Alice") }
+    let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
+    let(:token) { token_service.generate_token(user.userid, "api") }
 
-    it "will authenticate a user with a token" do
-      post(
-        "/graphql",
-        :headers => {"HTTP_X_AUTH_TOKEN" => token},
-        :params  => {:query => "{ viewer { name } }"},
-        :as      => :json
-      )
+    as_user(:name => 'Alice') do
+      it "will authenticate a user with a token" do
+        post(
+          "/graphql",
+          :headers => {"HTTP_X_AUTH_TOKEN" => token},
+          :params  => {:query => "{ viewer { name } }"},
+          :as      => :json
+        )
 
-      expected = {
-        "data" => {
-          "viewer" => {
-            "name" => "Alice"
+        expected = {
+          "data" => {
+            "viewer" => {
+              "name" => "Alice"
+            }
           }
         }
-      }
-      expect(response.parsed_body).to eq(expected)
+        expect(response.parsed_body).to eq(expected)
+      end
     end
   end
 

--- a/spec/integration/vms_spec.rb
+++ b/spec/integration/vms_spec.rb
@@ -1,29 +1,25 @@
 require "manageiq_helper"
 
 RSpec.describe "Vm queries" do
-  let(:server) { FactoryGirl.create(:miq_server) }
-  let(:user) { FactoryGirl.create(:user) }
   let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
   let(:token) { token_service.generate_token(user.userid, "api") }
 
-  before do
-    Tenant.create!(:use_config_for_attributes => false)
-    allow(MiqServer).to receive(:my_guid).and_return(server.guid)
-    MiqServer.my_server_clear_cache
-  end
-
   describe "'vms' field" do
-    it "will return the specified fields of all vms" do
-      FactoryGirl.create(:vm, :name => "Alice's VM")
+    as_user do
+      before do
+        FactoryGirl.create(:vm, :name => "Alice's VM")
+      end
 
-      post(
-        "/graphql",
-        :headers => {"HTTP_X_AUTH_TOKEN" => token},
-        :params  => {:query => "{ vms { name } }"},
-        :as      => :json
-      )
+      it "will return the specified fields of all vms" do
+        post(
+          "/graphql",
+          :headers => {"HTTP_X_AUTH_TOKEN" => token},
+          :params  => {:query => "{ vms { name } }"},
+          :as      => :json
+        )
 
-      expect(response.parsed_body).to eq("data" => {"vms" => [{"name" => "Alice's VM"}]})
+        expect(response.parsed_body).to eq("data" => {"vms" => [{"name" => "Alice's VM"}]})
+      end
     end
   end
 end

--- a/spec/manageiq_helper.rb
+++ b/spec/manageiq_helper.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
   config.expose_dsl_globally = true
 
   config.include ManageIQ::GraphQL::Engine.routes.url_helpers, :type => :routing
+  config.include IntegrationMacros, :type => :request
 end
 
 # Load test helpers from ManageIQ

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,5 @@ ENV['RAILS_ENV'] ||= 'test'
 RSpec.configure do |config|
 end
 
-Dir["./spec/support/**/*.rb"].each { |f| require f }
-
 require 'manageiq-graphql'
+Dir["./spec/support/**/*.rb"].each { |f| require f }

--- a/spec/support/integration_macros.rb
+++ b/spec/support/integration_macros.rb
@@ -1,0 +1,74 @@
+module IntegrationMacros
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    ##
+    # Creates a integration testing context with a particular
+    # type of user.
+    #
+    # Accepts keyword arguments which are given directly to
+    # the User factory to customize the user as the test sees fit.
+    #
+    # The 'role' keyword is the role to be given to the user;
+    # **For brevity, the role is mutated as the suffix of seeded MIQ roles:**
+    # 'administrator' -> 'EvmRole-administrator'
+    # If no role is given, 'user' (EvmRole-user) is used
+    #
+    # Example:
+    #
+    #  ```
+    #  describe 'when the app is down for maintenance' do
+    #    as_user(:role => 'super_administrator') do
+    #      it 'still allows the user to log in' do
+    #        # user's miq_user_role is 'EvmRole-super_administrator'
+    #      end
+    #    end
+    #
+    #    as_user(:name => "Chris") do
+    #      it 'doesn't allow the user to log in' do
+    #        # user's name is 'Chris'
+    #        # user's miq_user_role is 'EvmRole-user'
+    #      end
+    #    end
+    #  end
+    #  ```
+    def as_user(**user_factory_options, &block)
+      role = user_factory_options[:role] || 'user'
+      context "as #{indefinitize(role)}" do
+        let(:user) do
+          options = user_factory_options.merge(:role => "EvmRole-#{role}")
+          FactoryGirl.create(:user, options)
+        end
+        let(:server) { FactoryGirl.create(:miq_server) }
+
+        before do
+          create_primordials
+        end
+
+        class_exec(&block)
+      end
+    end
+
+    private
+
+    def indefinitize(word)
+      article = %w(a e i o u).include?(word[0].downcase) ? "an" : "a"
+      "#{article} #{word}"
+    end
+  end
+
+  def encode_basic_auth_credentials(user, password)
+    ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
+  end
+
+  private
+
+  ##
+  # Creates the minimum required records to have a functional
+  # integration test
+  def create_primordials
+    Tenant.create!(:use_config_for_attributes => false)
+    allow(MiqServer).to receive(:my_guid).and_return(server.guid)
+    MiqServer.my_server_clear_cache
+  end
+end

--- a/spec/support/integration_macros.rb
+++ b/spec/support/integration_macros.rb
@@ -51,9 +51,20 @@ module IntegrationMacros
 
     private
 
-    def indefinitize(word)
-      article = %w(a e i o u).include?(word[0].downcase) ? "an" : "a"
-      "#{article} #{word}"
+    A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija)$|e[uw]|uk|ubi|ubo|oaxaca|ufo|ur[aeiou]|use|ut([^t])|unani|uni(l[^l]|[a-ko-z]))/i
+    AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
+    private_constant :A_REQUIRING_PATTERNS, :AN_REQUIRING_PATTERNS
+
+    def indefinitize(word_or_phrase)
+      first_word = word_or_phrase.to_s.split(/[- ]/).first
+      article = unless first_word.nil?
+                  if (first_word[AN_REQUIRING_PATTERNS]) && !(first_word[A_REQUIRING_PATTERNS])
+                    'an'
+                  else
+                    'a'
+                  end
+                end
+      "#{article} #{word_or_phrase}"
     end
   end
 


### PR DESCRIPTION
In request specs, we're going to be doing a lot 'if you're this user, this happens'. We also have some weird primordial seeding we need to do. So let's put that all in a flexible helper that specs can use but hide all the nasty.  Also, abstract away some of the spec description details to keep it clean with minimal effort!