### PR TITLE
Support queries via GET/query string

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 ManageIQ::GraphQL::Engine.routes.draw do
-  root :to => 'graphql#execute', :as => :endpoint, :via => :post
+  root :to => 'graphql#execute', :as => :endpoint, :via => %i(get post)
 end
 
 Rails.application.routes.draw do

--- a/spec/integration/querying_spec.rb
+++ b/spec/integration/querying_spec.rb
@@ -12,5 +12,31 @@ RSpec.describe "Querying" do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq("data" => {"viewer" => {"name" => "Alice"}})
     end
+
+    example "queries can be sent in the query string via the POST method" do
+      query = CGI.escape("{viewer{name}}")
+
+      post(
+        "/graphql?query=#{query}",
+        :headers => {"Authorization" => encode_basic_auth_credentials(user.userid, user.password)},
+      )
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq("data" => {"viewer" => {"name" => "Alice"}})
+    end
+
+    it "favors the query string if both a query string and a JSON body are provided" do
+      query = CGI.escape("{viewer{name}}")
+
+      post(
+        "/graphql?query=#{query}",
+        :headers => {"Authorization" => encode_basic_auth_credentials(user.userid, user.password)},
+        :params  => {:query => "{ vms { name } }"},
+        :as      => :json
+      )
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq("data" => {"viewer" => {"name" => "Alice"}})
+    end
   end
 end

--- a/spec/integration/querying_spec.rb
+++ b/spec/integration/querying_spec.rb
@@ -1,0 +1,16 @@
+require "manageiq_helper"
+
+RSpec.describe "Querying" do
+  as_user(:name => "Alice", :userid => "Alice", :password => "alicepassword") do
+    example "queries can be sent in the query string via the GET method" do
+      get(
+        "/graphql",
+        :headers => {"Authorization" => encode_basic_auth_credentials(user.userid, user.password)},
+        :params  => {:query => "{ viewer { name } }"}
+      )
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq("data" => {"viewer" => {"name" => "Alice"}})
+    end
+  end
+end


### PR DESCRIPTION
According to http://graphql.org/learn/serving-over-http/#http-methods-headers-and-body, a GraphQL server should support GET requests in addition to POSTs, allowing queries to be sent in the query string. This adds support for that. 

It also mentions that it is recommended that queries can also be submitted via the query string in POST requests, and that the whole body of  the POST request can be interpreted as a GraphQL query if sending the `Content-Type: application/graphql` header.

The former appears to "just work" (I added a test for this), but the latter won't (and may be problematic - I'm recalling a conversation about this, but may need to research the specifics), so I'm leaving it here for now.

Resolves https://www.pivotaltracker.com/story/show/154581357