### PR TITLE
Relay - Global ID specification

### DIFF
--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -15,10 +15,13 @@ module ManageIQ
 
       resolve_type ->(_type, obj, _ctx) {
         # TODO: This resolver is incredibly naive and should be refactored.
-        if /Vm/ =~ obj.class.name
+        case obj.class.name
+        when /Vm/
           Types::Vm
-        elsif /Service/ =~ obj.class.name
+        when /Service/
           Types::Service
+        when /Host/
+          Types::Host
         end
       }
 

--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -14,14 +14,31 @@ module ManageIQ
       mutation Types::Mutation
 
       resolve_type ->(_type, obj, _ctx) {
-        # This is horrible. It's horrible because this is a PoC
-        # and it just needs to prove that one can resolve our AR models to
-        # GraphQL types. dealwithit.gif
+        # TODO: This resolver is incredibly naive and should be refactored.
         if /Vm/ =~ obj.class.name
           Types::Vm
         elsif /Service/ =~ obj.class.name
           Types::Service
         end
+      }
+
+      id_from_object ->(object, type_definition, _query_ctx) {
+        # Create UUIDs by joining the type name & ID, then base64-encoding it
+        ::GraphQL::Schema::UniqueWithinType.encode(type_definition.name, object.id)
+      }
+
+      object_from_id ->(id, _query_ctx) {
+        type_name, item_id = ::GraphQL::Schema::UniqueWithinType.decode(id)
+        # TODO: This resolver is incredibly naive and should be refactored.
+        model_klass = case type_name
+                      when /Vm/
+                        ::Vm
+                      when /Service/
+                        ::Service
+                      when /Host/
+                        ::Host
+                      end
+        model_klass.find(item_id)
       }
     end
   end

--- a/lib/manageiq/graphql/types/host.rb
+++ b/lib/manageiq/graphql/types/host.rb
@@ -6,7 +6,12 @@ module ManageIQ
         description "A computer on which virtual machine monitor software is loaded."
         interfaces [Taggable]
 
-        field :id, !types.ID, "The ID of the host"
+        global_id_field :id
+        field :database_id,
+              !types.ID,
+              "The database ID of the host",
+              :property           => :id,
+              :deprecation_reason => "This field may not be included in the ManageIQ Hammer release. Use the global Relay ID ('id') instead."
         field :name, !types.String, "The name of the host"
         field :hostname, types.String
         field :ipaddress, types.String

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -5,6 +5,9 @@ module ManageIQ
         name 'Query'
         description 'The root type for a query operation; a read-only fetch.'
 
+        field :node,  ::GraphQL::Relay::Node.field
+        field :nodes, ::GraphQL::Relay::Node.plural_field
+
         field :host, Host, "Look up a host by its ID" do
           argument :id, types.ID
 

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -8,15 +8,6 @@ module ManageIQ
         field :node,  ::GraphQL::Relay::Node.field
         field :nodes, ::GraphQL::Relay::Node.plural_field
 
-        field :host, Host, "Look up a host by its ID" do
-          argument :id, types.ID
-
-          resolve ->(_obj, args, _ctx) {
-            host = ::Host.find(args[:id])
-            ::Rbac.filtered_object(host)
-          }
-        end
-
         field :hosts, !types[Host], "List available hosts" do
           argument :tags, types[types.String]
 
@@ -27,15 +18,6 @@ module ManageIQ
                       ::Host.all
                     end
             ::Rbac.filtered(hosts)
-          }
-        end
-
-        field :service, Service, "Look up a service by its ID" do
-          argument :id, types.ID
-
-          resolve ->(_obj, args, _ctx) {
-            service = ::Service.find(args[:id])
-            ::Rbac.filtered_object(service)
           }
         end
 
@@ -61,15 +43,6 @@ module ManageIQ
         field :viewer, User, "The currently logged-in user" do
           resolve ->(_obj, _args, ctx) {
             ctx[:current_user]
-          }
-        end
-
-        field :vm, Vm, "Look up a virtual machine by its ID" do
-          argument :id, types.ID
-
-          resolve ->(_obj, args, _ctx) {
-            vm = ::Vm.find(args[:id])
-            ::Rbac.filtered_object(vm)
           }
         end
 

--- a/lib/manageiq/graphql/types/service.rb
+++ b/lib/manageiq/graphql/types/service.rb
@@ -4,9 +4,15 @@ module ManageIQ
       Service = ::GraphQL::ObjectType.define do
         name 'Service'
         description 'A Service is an item in a Service Catalog that can be requested.'
+        implements ::GraphQL::Relay::Node.interface
         interfaces [Taggable]
 
-        field :id, !types.ID, "The ID of the service"
+        global_id_field :id
+        field :database_id,
+              !types.ID,
+              "The database ID of the service",
+              :property           => :id,
+              :deprecation_reason => "This field may not be included in the ManageIQ Hammer release. Use the global Relay ID ('id') instead."
         field :name, !types.String, "The name of the service"
         field :description, types.String, "A human-readable description of the service"
         field :guid, types.ID, "The globally unique identifier of the service"

--- a/lib/manageiq/graphql/types/tag.rb
+++ b/lib/manageiq/graphql/types/tag.rb
@@ -4,7 +4,9 @@ module ManageIQ
       Tag = ::GraphQL::ObjectType.define do
         name 'Tag'
         description 'Tags are descriptive terms defined by a ManageIQ user or the system used to categorize a resource.'
+        implements ::GraphQL::Relay::Node.interface
 
+        global_id_field :id
         field :name, !types.String, "The name of the tag"
       end
     end

--- a/lib/manageiq/graphql/types/user.rb
+++ b/lib/manageiq/graphql/types/user.rb
@@ -4,8 +4,14 @@ module ManageIQ
       User = ::GraphQL::ObjectType.define do
         name 'User'
         description 'In Identity Service, each user is associated with one or more tenants, and in Compute can be associated with roles, projects, or both.'
+        implements ::GraphQL::Relay::Node.interface
 
-        field :id, !types.ID
+        global_id_field :id
+        field :database_id,
+              !types.ID,
+              "The database ID of the user",
+              :property           => :id,
+              :deprecation_reason => "This field may not be included in the ManageIQ Hammer release. Use the global Relay ID ('id') instead."
         field :name, !types.String
         field :email, !types.String
       end

--- a/lib/manageiq/graphql/types/vm.rb
+++ b/lib/manageiq/graphql/types/vm.rb
@@ -4,9 +4,15 @@ module ManageIQ
       Vm = ::GraphQL::ObjectType.define do
         name 'Vm'
         description 'A Virtual Machine is a software implementation of a system that functions similar to a physical machine. Virtual machines utilize the hardware infrastructure of a physical host, or a set of physical hosts, to provide a scalable and on-demand method of system provisioning.'
+        implements ::GraphQL::Relay::Node.interface
         interfaces [Taggable]
 
-        field :id, !types.ID, "The ID of the virtual machine"
+        global_id_field :id
+        field :database_id,
+              !types.ID,
+              "The database ID of the virtual machine",
+              :property           => :id,
+              :deprecation_reason => "This field may not be included in the ManageIQ Hammer release. Use the global Relay ID ('id') instead."
         field :vendor, !types.String, "The virtual machine's vendor"
         field :name, !types.String, "The name of the virtual machine"
         field :location, !types.String, "The location of the virtual machine"

--- a/spec/integration/relay_spec.rb
+++ b/spec/integration/relay_spec.rb
@@ -1,0 +1,56 @@
+require "manageiq_helper"
+
+RSpec.describe "Relay specification compliance (integration)" do
+  let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
+  let(:token) { token_service.generate_token(user.userid, "api") }
+
+  describe "Global Object Identification" do
+    context "given an object with an ID" do
+      as_user do
+        before do
+          FactoryGirl.create(:vm, :name => "Sooper Special VM")
+
+          post(
+            "/graphql",
+            :headers => { "HTTP_X_AUTH_TOKEN" => token },
+            :params  => { :query => "{ vms { id name } }" },
+            :as      => :json
+          )
+        end
+
+        example "the same object can be requeried by its node ID" do
+          vm_id = response.parsed_body['data']['vms'].first['id']
+
+          query = <<~QUERY
+            {
+              node(id: "#{vm_id}") {
+                id
+                ... on Vm {
+                  name
+                }
+              }
+            }
+          QUERY
+
+          post(
+            "/graphql",
+            :headers => { "HTTP_X_AUTH_TOKEN" => token },
+            :params  => { :query => query },
+            :as      => :json
+          )
+
+          expected = {
+            "data" => {
+              "node" => {
+                "id"   => vm_id,
+                "name" => "Sooper Special VM"
+              }
+            }
+          }
+
+          expect(response.parsed_body).to eq(expected)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/relay_spec.rb
+++ b/spec/unit/relay_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe "Relay specification compliance (unit)" do
+  describe "Global Object Identification" do
+    # https://facebook.github.io/relay/graphql/objectidentification.htm
+
+    context "introspection" do
+      let(:query) { '' }
+      let(:context) { {} }
+      let(:variables) { {} }
+      let(:result) do
+        ManageIQ::GraphQL::Schema.execute(
+          query,
+          :context   => context,
+          :variables => variables
+        )
+      end
+
+      describe "Node interface" do
+        let(:query) do
+          <<~QUERY
+            {
+              __type(name: "Node") {
+                name
+                kind
+                fields {
+                  name
+                  type {
+                    kind
+                    ofType {
+                      name
+                      kind
+                    }
+                  }
+                }
+              }
+            }
+          QUERY
+        end
+
+        it "follows section 2.1 of the global object identification spec" do
+          expected = { "__type" => { "name"   => "Node",
+                                     "kind"   => "INTERFACE",
+                                     "fields" => [{ "name" => "id",
+                                                    "type" => { "kind"   => "NON_NULL",
+                                                                "ofType" => { "name" => "ID",
+                                                                              "kind" => "SCALAR" }}}]}}
+
+          expect(result['data']).to eq(expected)
+        end
+      end
+
+      describe "Node root field" do
+        let(:query) do
+          <<~QUERY
+            {
+              __schema {
+                queryType {
+                  fields {
+                    name
+                    type {
+                      name
+                      kind
+                    }
+                    args {
+                      name
+                      type {
+                        kind
+                        ofType {
+                          name
+                          kind
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          QUERY
+        end
+
+        it "follows section 3.1 of the global object identification spec" do
+          expect(result['data']).to match(
+            "__schema" =>
+            { "queryType" =>
+              { "fields" =>
+                array_including(
+                  "name" => "node",
+                  "type" => {"name" => "Node", "kind" => "INTERFACE"},
+                  "args" => [{ "name" => "id", "type" => { "kind" => "NON_NULL", "ofType" => { "name" => "ID", "kind" => "SCALAR" } } }]
+                )
+              }
+            }
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
These changes contain the following interface changes:

* Adds Relay global object identification. The specification for this can be found [here](https://facebook.github.io/relay/graphql/objectidentification.htm). Note by specification the field is named `id` and replaces the actual database ID from Postgres - this has been renamed to `databaseId`
* Deprecates `databaseId`. In GraphQL this is considered *strictly an implementation detail.* I've left them here (but deprecated) purely for convenience when comparing things against the REST API. Note that GitHub's V4 API does exactly this as well.
* Removes lookups by database ID. While leaving the fields for `databaseId` is largely harmless, lookups via databaseId are considered incorrect and not proper GraphQL (and require much more maintenance on our end). While I expect to get a lot of flack for this, I would like to at least *try* to force users to actually adhere to Relay and use the GUIDs (`id`) for lookups. If clients insist they need the convenience of just entering the Postgres ID and object type, I'd like to remind them that IDs are encoded but not encrypted - clients can literally just add their own helpers for generating the ID as seen in the code here.

For more on "OMG you can't just not use database IDs!" please see bswinnerton's excellent answer on the GitHub forums to the question ["What is the reason databaseId field is deprecated?"](https://platform.github.community/t/what-is-the-reason-databaseid-field-is-deprecated/976/2)

https://www.pivotaltracker.com/story/show/154334996