### PR TITLE
Relay: Cursor Connections compliance

### DIFF
--- a/lib/manageiq/graphql.rb
+++ b/lib/manageiq/graphql.rb
@@ -1,3 +1,7 @@
+require 'rails'
+require 'action_controller/railtie'
+require 'active_record/railtie'
+
 require 'graphql'
 require 'graphql/batch'
 require 'graphql/preload'

--- a/lib/manageiq/graphql/engine.rb
+++ b/lib/manageiq/graphql/engine.rb
@@ -1,5 +1,3 @@
-require 'rails'
-require 'action_controller/railtie'
 require 'manageiq/graphql/rest_api_proxy'
 
 module ManageIQ

--- a/lib/manageiq/graphql/types/host.rb
+++ b/lib/manageiq/graphql/types/host.rb
@@ -44,7 +44,7 @@ module ManageIQ
         field :maintenance, types.Boolean
         field :maintenance_reason, types.String
 
-        field :vms, types[Vm], "The virtual machines associated with this host" do
+        connection :vms, !Vm.connection_type, "The virtual machines associated with this host" do
           preload :vms
         end
       end

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -8,7 +8,7 @@ module ManageIQ
         field :node,  ::GraphQL::Relay::Node.field
         field :nodes, ::GraphQL::Relay::Node.plural_field
 
-        field :hosts, !types[Host], "List available hosts" do
+        connection :hosts, !Host.connection_type, "List available hosts" do
           argument :tags, types[types.String]
 
           resolve ->(_obj, args, _ctx) {
@@ -21,7 +21,7 @@ module ManageIQ
           }
         end
 
-        field :services, !types[Service], "List available services" do
+        connection :services, !Service.connection_type, "List available services" do
           argument :tags, types[types.String]
 
           resolve ->(_obj, args, _ctx) {
@@ -34,7 +34,7 @@ module ManageIQ
           }
         end
 
-        field :tags, !types[Tag], "List available tags" do
+        connection :tags, !Tag.connection_type, "List available tags" do
           resolve ->(_obj, _args, _ctx) {
             ::Rbac.filtered(::Tag.all)
           }
@@ -46,7 +46,7 @@ module ManageIQ
           }
         end
 
-        field :vms, !types[Vm], "List available virtual machines" do
+        connection :vms, !Vm.connection_type, "List available virtual machines" do
           argument :tags, types[types.String]
 
           resolve ->(_obj, args, _ctx) {

--- a/lib/manageiq/graphql/types/service.rb
+++ b/lib/manageiq/graphql/types/service.rb
@@ -20,11 +20,8 @@ module ManageIQ
         field :display, !types.Boolean, "A true/false value determining if the service should be displayed"
         field :retired, !types.Boolean, "A true/false value as to whether the service is retired or not"
         field :retires_on, DateTime, "A string representation of the date this service is to be retired"
-        field :vms, types[Vm], "The virtual machines associated with this service" do
-          resolve ->(object, _args, _ctx) {
-            object.vms
-          }
-        end
+
+        connection :vms, !Vm.connection_type, "The virtual machines associated with this service"
       end
     end
   end

--- a/lib/manageiq/graphql/types/vm.rb
+++ b/lib/manageiq/graphql/types/vm.rb
@@ -29,7 +29,8 @@ module ManageIQ
         field :ems_ref, types.ID, "The unique identifier of the virtual machine frome the native provider"
         field :cloud, types.Boolean, "Returns true for cloud virtual machines, false for infrastructure virtual machines"
         field :raw_power_state, types.String, "The power state of the virtual machine, as described by the provider"
-        field :service, Service, "The service object associated with this virtual machine" do
+
+        connection :service, !Service.connection_type, "The service object associated with this virtual machine" do
           preload :direct_services
 
           resolve ->(object, _args, _ctx) {

--- a/spec/integration/relay_spec.rb
+++ b/spec/integration/relay_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe "Relay specification compliance (integration)" do
           post(
             "/graphql",
             :headers => { "HTTP_X_AUTH_TOKEN" => token },
-            :params  => { :query => "{ vms { id name } }" },
+            :params  => { :query => "{ vms { edges { node { id name } } } }" },
             :as      => :json
           )
         end
 
         example "the same object can be requeried by its node ID" do
-          vm_id = response.parsed_body['data']['vms'].first['id']
+          vm_id = response.parsed_body.dig('data', 'vms', 'edges').first.dig('node', 'id')
 
           query = <<~QUERY
             {

--- a/spec/integration/vms_spec.rb
+++ b/spec/integration/vms_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe "Vm queries" do
         post(
           "/graphql",
           :headers => {"HTTP_X_AUTH_TOKEN" => token},
-          :params  => {:query => "{ vms { name } }"},
+          :params  => {:query => "{ vms { edges { node { name } } } }"},
           :as      => :json
         )
 
-        expect(response.parsed_body).to eq("data" => {"vms" => [{"name" => "Alice's VM"}]})
+        expect(response.parsed_body).to eq("data" => {"vms" => { "edges" => [{ "node" => {"name" => "Alice's VM"} }] } })
       end
     end
   end


### PR DESCRIPTION
Changes all one to many fields to support Relay cursor connections as put forth in the Relay Cursor Connections Specification: https://facebook.github.io/relay/graphql/connections.htm

![](http://screenshots.chrisarcand.com/65l05.jpg)

![](http://screenshots.chrisarcand.com/cre8s.jpg)

![](http://screenshots.chrisarcand.com/3b4gi.jpg)

![](http://screenshots.chrisarcand.com/2jmpi.jpg)