### PR TITLE
Relay compliance, Episode III: Mutations

### DIFF
--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -13,7 +13,7 @@ module ManageIQ
       query Types::Query
       mutation Types::Mutation
 
-      resolve_type ->(_type, obj, _ctx) {
+      resolve_type ->(_abstract_type, obj, _ctx) {
         # TODO: This resolver is incredibly naive and should be refactored.
         case obj.class.name
         when /Vm/

--- a/lib/manageiq/graphql/types/mutation.rb
+++ b/lib/manageiq/graphql/types/mutation.rb
@@ -5,24 +5,7 @@ module ManageIQ
         name 'Mutation'
         description 'The root type for a mutation operation; a write followed by fetch.'
 
-        # Note: These are incredibly naive ways of doing a mutation.
-        # Mutations should be implemented with object identification conforming
-        # to the Relay specification:
-        # https://facebook.github.io/relay/graphql/objectidentification.htm
-        field :addTags, Taggable do
-          description "Adds tags to a Taggable"
-          argument :taggableId, !types.ID
-          argument :taggableType, !types.String
-          argument :tagNames, !types[types.String]
-
-          resolve ->(_object, args, _ctx) {
-            # WARNING: This isn't actually safe, it's merely for PoC
-            klass = "::#{args[:taggableType]}".constantize
-            taggable = klass.find(args[:taggableId])
-            taggable.tag_add(args[:tagNames])
-            taggable.reload
-          }
-        end
+        field :addTags, :field => Mutations::AddTags.field
 
         field :removeTags, Taggable do
           description "Remove tags from a Taggable"

--- a/lib/manageiq/graphql/types/mutation.rb
+++ b/lib/manageiq/graphql/types/mutation.rb
@@ -7,38 +7,7 @@ module ManageIQ
 
         field :addTags, :field => Mutations::AddTags.field
         field :removeTags, :field => Mutations::RemoveTags.field
-
-        # TODO: This is very PoC
-        field :performVmPowerOperation, ActionResultPayload do
-          name 'performVmPowerOperation'
-          description "Perform power operations on Virtual Machines"
-          argument :vm_id, !types.ID
-          argument :operation, VmPowerOperation
-
-          resolve ->(_object, args, _ctx) {
-            begin
-              vm = ::Vm.find(args[:vm_id])
-              vm = ::Rbac.filtered_object(vm)
-              description = "Performing #{args[:operation]} operation on VM id: #{vm.id}, name: '#{vm.name}'"
-
-              task_id = QueueService.enqueue(
-                vm,
-                description,
-                :method_name => args[:operation],
-                :role        => "ems_operations"
-              )
-
-              # TODO: ActionResultPayloads probably won't be a thing anyway, but even if they were to be
-              # this should be a proper object mapping to that type, not just OpenStruct....maybe.
-              # TODO: We shouldn't be rescuing all errors like we do in the REST API.
-              # We should be explicitly defining exceptional behavior from core and returning that, but
-              # properly raising our own faults.
-              OpenStruct.new(:success => true, :message => description, :task_id => task_id)
-            rescue StandardError => error
-              OpenStruct.new(:success => false, :message => error.to_s)
-            end
-          }
-        end
+        field :performVmPowerOperation, :field => Mutations::PerformVmPowerOperation.field
       end
     end
   end

--- a/lib/manageiq/graphql/types/mutation.rb
+++ b/lib/manageiq/graphql/types/mutation.rb
@@ -6,21 +6,7 @@ module ManageIQ
         description 'The root type for a mutation operation; a write followed by fetch.'
 
         field :addTags, :field => Mutations::AddTags.field
-
-        field :removeTags, Taggable do
-          description "Remove tags from a Taggable"
-          argument :taggableId, !types.ID
-          argument :taggableType, !types.String
-          argument :tagNames, !types[types.String]
-
-          resolve ->(_object, args, _ctx) {
-            # WARNING: This isn't actually safe, it's merely for PoC
-            klass = "::#{args[:taggableType]}".constantize
-            taggable = klass.find(args[:taggableId])
-            taggable.tag_remove(args[:tagNames])
-            taggable.reload
-          }
-        end
+        field :removeTags, :field => Mutations::RemoveTags.field
 
         # TODO: This is very PoC
         field :performVmPowerOperation, ActionResultPayload do

--- a/lib/manageiq/graphql/types/mutations/add_tags.rb
+++ b/lib/manageiq/graphql/types/mutations/add_tags.rb
@@ -1,0 +1,24 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      module Mutations
+        AddTags = ::GraphQL::Relay::Mutation.define do
+          name 'AddTags'
+
+          input_field :taggableId, !types.ID
+          input_field :tagNames, !types[types.String]
+
+          return_field :taggable, Taggable
+
+          resolve ->(_object, args, ctx) {
+            taggable = Schema.object_from_id(args['taggableId'], ctx)
+            taggable.tag_add(args[:tagNames])
+            taggable.reload
+
+            { :taggable => taggable }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/mutations/perform_vm_power_operation.rb
+++ b/lib/manageiq/graphql/types/mutations/perform_vm_power_operation.rb
@@ -15,16 +15,16 @@ module ManageIQ
             begin
               vm = Schema.object_from_id(args[:vmId], ctx)
               vm = ::Rbac.filtered_object(vm)
-              description = "Performing #{args[:operation]} operation on VM id: #{vm.id}, name: '#{vm.name}'"
+              description = lambda { |id| "Performing #{args[:operation]} operation on VM id: #{id}, name: '#{vm.name}'" }
 
               task_id = QueueService.enqueue(
                 vm,
-                description,
+                description.call(vm.id),
                 :method_name => args[:operation],
                 :role        => "ems_operations"
               )
 
-              { :success => true, :message => description, :taskId => task_id }
+              { :success => true, :message => description.call(args[:vmId]), :taskId => task_id }
             rescue StandardError => error
               { :success => false, :message => error.to_s }
             end

--- a/lib/manageiq/graphql/types/mutations/perform_vm_power_operation.rb
+++ b/lib/manageiq/graphql/types/mutations/perform_vm_power_operation.rb
@@ -1,0 +1,36 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      module Mutations
+        PerformVmPowerOperation = ::GraphQL::Relay::Mutation.define do
+          name 'PerformVmPowerOperation'
+          description "Perform power operations on Virtual Machines"
+
+          input_field :vmId, !types.ID
+          input_field :operation, !VmPowerOperation
+
+          return_interfaces [QueueResultPayload]
+
+          resolve ->(_object, args, ctx) {
+            begin
+              vm = Schema.object_from_id(args[:vmId], ctx)
+              vm = ::Rbac.filtered_object(vm)
+              description = "Performing #{args[:operation]} operation on VM id: #{vm.id}, name: '#{vm.name}'"
+
+              task_id = QueueService.enqueue(
+                vm,
+                description,
+                :method_name => args[:operation],
+                :role        => "ems_operations"
+              )
+
+              { :success => true, :message => description, :taskId => task_id }
+            rescue StandardError => error
+              { :success => false, :message => error.to_s }
+            end
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/mutations/remove_tags.rb
+++ b/lib/manageiq/graphql/types/mutations/remove_tags.rb
@@ -1,0 +1,24 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      module Mutations
+        RemoveTags = ::GraphQL::Relay::Mutation.define do
+          name 'RemoveTags'
+
+          input_field :taggableId, !types.ID
+          input_field :tagNames, !types[types.String]
+
+          return_field :taggable, Taggable
+
+          resolve ->(_object, args, ctx) {
+            taggable = Schema.object_from_id(args['taggableId'], ctx)
+            taggable.tag_remove(args[:tagNames])
+            taggable.reload
+
+            { :taggable => taggable }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/queue_result.rb
+++ b/lib/manageiq/graphql/types/queue_result.rb
@@ -1,0 +1,13 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      QueueResultPayload = ::GraphQL::InterfaceType.define do
+        name 'QueueResultPayload'
+
+        field :success, !types.Boolean
+        field :message, types.String
+        field :taskId, types.ID
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/queue_result.rb
+++ b/lib/manageiq/graphql/types/queue_result.rb
@@ -3,6 +3,7 @@ module ManageIQ
     module Types
       QueueResultPayload = ::GraphQL::InterfaceType.define do
         name 'QueueResultPayload'
+        description "An interface type for queue-related payloads. All mutations which delegate to ManageIQ's queue return a payload which implement this inteface."
 
         field :success, !types.Boolean
         field :message, types.String

--- a/spec/integration/mutations/perform_vm_power_operation_spec.rb
+++ b/spec/integration/mutations/perform_vm_power_operation_spec.rb
@@ -1,0 +1,40 @@
+require "manageiq_helper"
+
+RSpec.describe 'performVmPowerOperation' do
+  let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
+  let(:token) { token_service.generate_token(user.userid, "api") }
+  let(:vm) { FactoryGirl.create(:vm) }
+
+  as_user do
+    let(:query) do
+      <<~QUERY
+        mutation {
+          performVmPowerOperation(input:{vmId: "#{relay_id_from(vm)}", operation: START}) {
+            success
+            message
+            taskId
+          }
+        }
+      QUERY
+    end
+
+    it "responds with a successful payload" do
+      expect(ManageIQ::GraphQL::QueueService).to receive(:enqueue).and_return(1337)
+
+      post(
+        "/graphql",
+        :headers => { "HTTP_X_AUTH_TOKEN" => token },
+        :params  => { :query => query },
+        :as      => :json
+      )
+
+      expected = {
+        "success" => true,
+        "message" => a_string_including("Performing start operation"),
+        "taskId"  => "1337"
+      }
+
+      expect(response.parsed_body['data']['performVmPowerOperation']).to match(expected)
+    end
+  end
+end

--- a/spec/integration/mutations/perform_vm_power_operation_spec.rb
+++ b/spec/integration/mutations/perform_vm_power_operation_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'performVmPowerOperation' do
 
       expected = {
         "success" => true,
-        "message" => a_string_including("Performing start operation"),
+        "message" => a_string_including("Performing start operation on VM id: #{relay_id_from(vm)}"),
         "taskId"  => "1337"
       }
 

--- a/spec/integration/tagging_spec.rb
+++ b/spec/integration/tagging_spec.rb
@@ -1,0 +1,53 @@
+require "manageiq_helper"
+
+RSpec.describe "Tagging" do
+  let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
+  let(:token) { token_service.generate_token(user.userid, "api") }
+
+  let(:taggable) { FactoryGirl.create(:vm, :name => "Sooper Cool VM") }
+
+  describe "addTags mutation" do
+    let(:mutation) do
+      <<~MUTATION
+        mutation {
+          addTags(input:{taggableId:"#{relay_id_from(taggable)}", tagNames: ["AddedTag1", "AddedTag2"]}) {
+            taggable {
+              ... on Vm {
+                name
+              }
+              tags {
+                name
+              }
+            }
+          }
+        }
+      MUTATION
+    end
+
+    as_user do
+      it "will add the tags to the taggable" do
+        expect {
+          post(
+            "/graphql",
+            :headers => {"HTTP_X_AUTH_TOKEN" => token},
+            :params  => {:query => mutation},
+            :as      => :json
+          )
+        }.to change { taggable.tags.reload.size }.from(0).to(2)
+
+        expected = {
+          "data" => {
+            "addTags" => {
+              "taggable" => {
+                "name" => "Sooper Cool VM",
+                "tags" => match_array([{ "name" => "/user/AddedTag1" }, { "name" => "/user/AddedTag2" }])
+              }
+            }
+          }
+        }
+
+        expect(response.parsed_body).to match(expected)
+      end
+    end
+  end
+end

--- a/spec/integration/tagging_spec.rb
+++ b/spec/integration/tagging_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Tagging" do
   let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
   let(:token) { token_service.generate_token(user.userid, "api") }
 
-  let(:taggable) { FactoryGirl.create(:vm, :name => "Sooper Cool VM") }
-
   describe "addTags mutation" do
+    let(:taggable) { FactoryGirl.create(:vm, :name => "Sooper Cool VM") }
+
     let(:mutation) do
       <<~MUTATION
         mutation {
@@ -41,6 +41,63 @@ RSpec.describe "Tagging" do
               "taggable" => {
                 "name" => "Sooper Cool VM",
                 "tags" => match_array([{ "name" => "/user/AddedTag1" }, { "name" => "/user/AddedTag2" }])
+              }
+            }
+          }
+        }
+
+        expect(response.parsed_body).to match(expected)
+      end
+    end
+  end
+
+  describe "removeTags mutation" do
+    let(:tags) do
+      tags = []
+      %w(tag1 tag2 tag3).each do |name|
+        tags << Tag.create(:name => "/user/#{name}")
+      end
+      tags
+    end
+
+    let(:taggable) do
+      FactoryGirl.create(:vm, :name => "Sooper Cool VM", :tags => tags)
+    end
+
+    let(:mutation) do
+      <<~MUTATION
+        mutation {
+          removeTags(input:{taggableId:"#{relay_id_from(taggable)}", tagNames: ["tag1", "tag3"]}) {
+            taggable {
+              ... on Vm {
+                name
+              }
+              tags {
+                name
+              }
+            }
+          }
+        }
+      MUTATION
+    end
+
+    as_user do
+      it "will remove tags from the taggable" do
+        expect {
+          post(
+            "/graphql",
+            :headers => {"HTTP_X_AUTH_TOKEN" => token},
+            :params  => {:query => mutation},
+            :as      => :json
+          )
+        }.to change { taggable.tags.reload.size }.from(3).to(1)
+
+        expected = {
+          "data" => {
+            "removeTags" => {
+              "taggable" => {
+                "name" => "Sooper Cool VM",
+                "tags" => match_array([{ "name" => "/user/tag2" }])
               }
             }
           }

--- a/spec/support/integration_macros.rb
+++ b/spec/support/integration_macros.rb
@@ -72,6 +72,13 @@ module IntegrationMacros
     ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
   end
 
+  ##
+  # Given an internal object (such as an ActiveRecord instance), returns the Relay ID for it
+  def relay_id_from(object)
+    type = ManageIQ::GraphQL::Schema.resolve_type(nil, object, nil)
+    ManageIQ::GraphQL::Schema.id_from_object(object, type, nil)
+  end
+
   private
 
   ##


### PR DESCRIPTION
Converts all of our current mutations in to Relay compliant ones as outlined in the specification for Relay Input Object Mutations: https://facebook.github.io/relay/graphql/mutations.htm

![](http://screenshots.chrisarcand.com/dxfjf.jpg)

Example `addTags` mutation:

![](http://screenshots.chrisarcand.com/22d88.jpg)

Example `performVmPowerOperation`:

![](http://screenshots.chrisarcand.com/nz2px.jpg)

### Other notes

* Introduces a QueueResultPayload type - an interface type which all mutations that delegate to the queue should implement and use. It's directly synonymous with the REST API's 'action result', formalized.

![](http://screenshots.chrisarcand.com/6uocu.jpg)

* Adds a `relay_id_from` spec helper to aid with converting back and forth from Relay IDs in tests.

Closes https://www.pivotaltracker.com/story/show/154335046 and completes the Relay epic!