### PR TITLE
Add a graphql-explorer plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@
 /.bundle/
 /.yardoc
 /Gemfile.lock
+/yarn.lock
 /_yardoc/
 /coverage/
 /doc/
+/node_modules/
 /pkg/
 /spec/reports/
 /tmp/

--- a/app/javascript/graphql-explorer/components/GraphQLExplorer.js
+++ b/app/javascript/graphql-explorer/components/GraphQLExplorer.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import GraphiQL from 'graphiql';
+
+export default class GraphQLExplorer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      fetcher: this.props.fetcher
+    };
+  }
+
+  render() {
+    return (
+      <GraphiQL ref={c => { this.graphiql = c; }} {...this.state}>
+        <GraphiQL.Logo>
+          ManageIQ GraphQL Explorer
+        </GraphiQL.Logo>
+      </GraphiQL>
+    );
+  }
+}

--- a/app/javascript/graphql-explorer/helpers/graphQLFetcher.js
+++ b/app/javascript/graphql-explorer/helpers/graphQLFetcher.js
@@ -1,0 +1,19 @@
+export default (graphQLParams) => {
+  return fetch('/graphql', {
+    method: 'post',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'X-Auth-Token': localStorage.miq_token
+    },
+    body: JSON.stringify(graphQLParams),
+  }).then(function (response) {
+    return response.text();
+  }).then(function (responseBody) {
+    try {
+      return JSON.parse(responseBody);
+    } catch (error) {
+      return responseBody;
+    }
+  });
+}

--- a/app/javascript/graphql-explorer/index.js
+++ b/app/javascript/graphql-explorer/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import GraphQLExplorer from './components/GraphQLExplorer';
+import graphQLFetcher from './helpers/graphQLFetcher';
+
+export default () => (
+    <GraphQLExplorer fetcher={graphQLFetcher} />
+);

--- a/app/javascript/packs/graphql-explorer.js
+++ b/app/javascript/packs/graphql-explorer.js
@@ -1,0 +1,6 @@
+import GraphQLExplorer from "../graphql-explorer";
+
+window.MiqReact.componentRegistry.register({
+  name: "graphql_explorer",
+  type: GraphQLExplorer
+});

--- a/lib/manageiq/graphql/engine.rb
+++ b/lib/manageiq/graphql/engine.rb
@@ -25,6 +25,10 @@ module ManageIQ
         app.middleware.use(ManageIQ::GraphQL::RESTAPIProxy)
       end
 
+      initializer "graphql.assets" do |app|
+        app.config.assets.paths << root.join("node_modules").to_s
+      end
+
       def vmdb_plugin?
         true
       end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "graphiql": "^0.11.11",
+    "react": "^16.2.0"
+  }
+}


### PR DESCRIPTION
Adds a graphql-explorer pack that contains our customized GraphiQL
React component. The component will register itself in the component
registry, but it is left to the classic UI repo to embed this in a
page and deal with menu items, etc..

See https://github.com/ManageIQ/manageiq-ui-classic/pull/3357 for accompanying work