### PR TITLE
Raise CodeClimate similarity mass

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,9 @@
 ---
+version: "2"  # required to adjust maintainability checks (https://docs.codeclimate.com/docs/advanced-configuration#section-default-checks)
+checks:
+  similar-code:
+    config:
+      threshold: 50
 exclude_paths:
 - ".git/"
 - "**.xml"


### PR DESCRIPTION
We're getting warnings of 'similar code' because the large nesting of
ManageIQ::GraphQL::Normal::Namespacing in each file looks like
duplication.

*whispers* I don't think you know what DRY means

---

I chose 50 because most of the offenders of this namespacing bit have a
mass of 49.