### PR TITLE
Instrument all fields to camelcase

### DIFF
--- a/lib/manageiq/graphql/field_name_camelizer.rb
+++ b/lib/manageiq/graphql/field_name_camelizer.rb
@@ -1,0 +1,20 @@
+module ManageIQ
+  module GraphQL
+    class FieldNameCamelizer
+      def instrument(_type, field)
+        field.property = field.name.underscore.to_sym if field.resolve_proc.kind_of?(::GraphQL::Field::Resolve::NameResolve)
+        field.name = field.name.camelize(:lower)
+
+        field.arguments = Hash[
+          field.arguments.map do |_name, argument|
+            argument.as = argument.name.underscore
+            argument.name = argument.name.camelize(:lower)
+            [argument.name, argument]
+          end
+        ]
+
+        field
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -10,6 +10,8 @@ module ManageIQ
       raise_definition_error true
       enable_preloading
 
+      instrument(:field, FieldNameCamelizer.new)
+
       query Types::Query
       mutation Types::Mutation
 

--- a/lib/manageiq/graphql/types/mutations/perform_vm_power_operation.rb
+++ b/lib/manageiq/graphql/types/mutations/perform_vm_power_operation.rb
@@ -24,7 +24,7 @@ module ManageIQ
                 :role        => "ems_operations"
               )
 
-              { :success => true, :message => description.call(args[:vmId]), :taskId => task_id }
+              { :success => true, :message => description.call(args[:vmId]), :task_id => task_id }
             rescue StandardError => error
               { :success => false, :message => error.to_s }
             end

--- a/lib/manageiq/graphql/types/queue_result.rb
+++ b/lib/manageiq/graphql/types/queue_result.rb
@@ -7,7 +7,7 @@ module ManageIQ
 
         field :success, !types.Boolean
         field :message, types.String
-        field :taskId, types.ID
+        field :task_id, types.ID
       end
     end
   end


### PR DESCRIPTION
While it's not required by the GraphQL spec, it's an established convention that GraphQL fields are defined in camelCase (and everything is case sensitive).

Because we're in Rubyland, we're used to underscored things, and all of the underlying methods that fields use are in underscores. To achieve camelCase in the actual field name, you thus need to do one of the following:

```ruby
field :someCoolData, :property => :some_cool_data
```

OR

```ruby
field :some_cool_property, :as => :someCoolData
```

To avoid having to add something like this for every single multiword attribute in our models (and thus introducing an easy way to accidentally introduce an underscored field that we'd need to deprecate to correct), FieldNameCamelizer is a instrumentation added to all fields which converts all field names to camelCase if they aren't already. I'm not typically a fan of implicit things like this but it could avoid future accidents and instrumentation is done at schema load time, not runtime in a query like middleware. (there's no request overhead)

cc/ @Fryguy as I remember you asking about something, I don't remember what, but I recall giving instrumentation as a solution. Here's one of many ways you can use instrumentation, for reference.