### PR TITLE
Add `execute_graphql` integration macro

### DIFF
--- a/spec/integration/mutations/perform_vm_power_operation_spec.rb
+++ b/spec/integration/mutations/perform_vm_power_operation_spec.rb
@@ -1,8 +1,6 @@
 require "manageiq_helper"
 
 RSpec.describe 'performVmPowerOperation' do
-  let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
-  let(:token) { token_service.generate_token(user.userid, "api") }
   let(:vm) { FactoryGirl.create(:vm) }
 
   as_user do
@@ -21,12 +19,7 @@ RSpec.describe 'performVmPowerOperation' do
     it "responds with a successful payload" do
       expect(ManageIQ::GraphQL::QueueService).to receive(:enqueue).and_return(1337)
 
-      post(
-        "/graphql",
-        :headers => { "HTTP_X_AUTH_TOKEN" => token },
-        :params  => { :query => query },
-        :as      => :json
-      )
+      execute_graphql(query)
 
       expected = {
         "success" => true,

--- a/spec/integration/tagging_spec.rb
+++ b/spec/integration/tagging_spec.rb
@@ -1,9 +1,6 @@
 require "manageiq_helper"
 
 RSpec.describe "Tagging" do
-  let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
-  let(:token) { token_service.generate_token(user.userid, "api") }
-
   describe "addTags mutation" do
     let(:taggable) { FactoryGirl.create(:vm, :name => "Sooper Cool VM") }
 
@@ -27,12 +24,7 @@ RSpec.describe "Tagging" do
     as_user do
       it "will add the tags to the taggable" do
         expect {
-          post(
-            "/graphql",
-            :headers => {"HTTP_X_AUTH_TOKEN" => token},
-            :params  => {:query => mutation},
-            :as      => :json
-          )
+          execute_graphql(mutation)
         }.to change { taggable.tags.reload.size }.from(0).to(2)
 
         expected = {
@@ -84,12 +76,7 @@ RSpec.describe "Tagging" do
     as_user do
       it "will remove tags from the taggable" do
         expect {
-          post(
-            "/graphql",
-            :headers => {"HTTP_X_AUTH_TOKEN" => token},
-            :params  => {:query => mutation},
-            :as      => :json
-          )
+          execute_graphql(mutation)
         }.to change { taggable.tags.reload.size }.from(3).to(1)
 
         expected = {

--- a/spec/integration/vms_spec.rb
+++ b/spec/integration/vms_spec.rb
@@ -1,9 +1,6 @@
 require "manageiq_helper"
 
 RSpec.describe "Vm queries" do
-  let(:token_service) { Api::UserTokenService.new(:base => {:module => "api", :name => "API"}) }
-  let(:token) { token_service.generate_token(user.userid, "api") }
-
   describe "'vms' field" do
     as_user do
       before do
@@ -11,12 +8,17 @@ RSpec.describe "Vm queries" do
       end
 
       it "will return the specified fields of all vms" do
-        post(
-          "/graphql",
-          :headers => {"HTTP_X_AUTH_TOKEN" => token},
-          :params  => {:query => "{ vms { edges { node { name } } } }"},
-          :as      => :json
-        )
+        execute_graphql <<~QUERY
+          {
+            vms {
+              edges {
+                node {
+                  name
+                }
+              }
+            }
+          }
+        QUERY
 
         expect(response.parsed_body).to eq("data" => {"vms" => { "edges" => [{ "node" => {"name" => "Alice's VM"} }] } })
       end


### PR DESCRIPTION
This consolidates on all the ceremony we have setting up a user token to make a proper request in integration tests. It pairs nicely with `as_user` but the only real requirement it has is to have a user defined (either in a variable or memoized helper, whatever)

As there's plenty of implied magic happening, I've also added a custom error to help newcomers find their way when trying to use it:

![](http://screenshots.chrisarcand.com/25zqr.jpg)