### PR TITLE
missing babel presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,9 @@
   "dependencies": {
     "graphiql": "^0.11.11",
     "react": "^16.2.0"
+  },
+  "devDependencies": {
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-react": "^6.24.1"
   }
 }


### PR DESCRIPTION
hello ;)

we seemed to have found the following issue when attempting to load the graphql-explorer (webpack'd plugin) alongside the [v2v](https://github.com/priley86/miq_v2v_ui_plugin) (webpack'd plugin):

http://pastebin.test.redhat.com/562325

Adding the following presets seems to resolve this for now...

