### PR TITLE
Extract interfaces for vms, hosts providers

### DIFF
--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -22,8 +22,8 @@ module ManageIQ
           Types::VmVmware
         when /Service/
           Types::Service
-        when /Host/
-          Types::Host
+        when /ManageIQ::Providers::Vmware::InfraManager::Host/
+          Types::HostVmware
         end
       }
 

--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -24,6 +24,8 @@ module ManageIQ
           Types::Service
         when /ManageIQ::Providers::Vmware::InfraManager::Host/
           Types::HostVmware
+        when /ManageIQ::Providers::Vmware::InfraManager/
+          Types::ProviderVmware
         end
       }
 
@@ -36,6 +38,8 @@ module ManageIQ
         type_name, item_id = ::GraphQL::Schema::UniqueWithinType.decode(id)
         # TODO: This resolver is incredibly naive and should be refactored.
         model_klass = case type_name
+                      when /Provider/
+                        ::ExtManagementSystem
                       when /Vm/
                         ::Vm
                       when /Service/

--- a/lib/manageiq/graphql/schema.rb
+++ b/lib/manageiq/graphql/schema.rb
@@ -18,8 +18,8 @@ module ManageIQ
       resolve_type ->(_abstract_type, obj, _ctx) {
         # TODO: This resolver is incredibly naive and should be refactored.
         case obj.class.name
-        when /Vm/
-          Types::Vm
+        when /ManageIQ::Providers::Vmware::InfraManager::Vm/
+          Types::VmVmware
         when /Service/
           Types::Service
         when /Host/

--- a/lib/manageiq/graphql/types/host.rb
+++ b/lib/manageiq/graphql/types/host.rb
@@ -1,10 +1,9 @@
 module ManageIQ
   module GraphQL
     module Types
-      Host = ::GraphQL::ObjectType.define do
+      Host = ::GraphQL::InterfaceType.define do
         name "Host"
         description "A computer on which virtual machine monitor software is loaded."
-        interfaces [Taggable]
 
         global_id_field :id
         field :database_id,

--- a/lib/manageiq/graphql/types/host_vmware.rb
+++ b/lib/manageiq/graphql/types/host_vmware.rb
@@ -1,0 +1,11 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      HostVmware = ::GraphQL::ObjectType.define do
+        name "HostVmware"
+        implements ::GraphQL::Relay::Node.interface
+        interfaces [Taggable, Host]
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/provider.rb
+++ b/lib/manageiq/graphql/types/provider.rb
@@ -1,10 +1,9 @@
 module ManageIQ
   module GraphQL
     module Types
-      Provider = ::GraphQL::ObjectType.define do
+      Provider = ::GraphQL::InterfaceType.define do
         name "Provider"
         description "A provider is a server with software to manage multiple virtual machines that reside on multiple hosts"
-        interfaces [Taggable]
 
         global_id_field :id
         field :database_id,

--- a/lib/manageiq/graphql/types/provider_vmware.rb
+++ b/lib/manageiq/graphql/types/provider_vmware.rb
@@ -1,0 +1,11 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      ProviderVmware = ::GraphQL::ObjectType.define do
+        name "ProviderVmware"
+        implements ::GraphQL::Relay::Node.interface
+        interfaces [Taggable, Provider]
+      end
+    end
+  end
+end

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -8,6 +8,19 @@ module ManageIQ
         field :node,  ::GraphQL::Relay::Node.field
         field :nodes, ::GraphQL::Relay::Node.plural_field
 
+        connection :vmware_hosts, !HostVmware.connection_type, "List available VmWare hosts" do
+          argument :tags, types[types.String]
+
+          resolve ->(_obj, args, _ctx) {
+            hosts = if args[:tags]
+                      ::ManageIQ::Providers::Vmware::InfraManager::Host.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
+                    else
+                      ::ManageIQ::Providers::Vmware::InfraManager::Host.all
+                    end
+            ::Rbac.filtered(hosts)
+          }
+        end
+
         connection :hosts, !Host.connection_type, "List available hosts" do
           argument :tags, types[types.String]
 

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -59,6 +59,19 @@ module ManageIQ
           }
         end
 
+        connection :vmware_vms, !VmVmware.connection_type, "List available Vmware virtual machines" do
+          argument :tags, types[types.String]
+
+          resolve ->(_obj, args, _ctx) {
+            vms = if args[:tags]
+                    ::ManageIQ::Providers::Vmware::InfraManager::Vm.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
+                  else
+                    ::ManageIQ::Providers::Vmware::InfraManager::Vm.all
+                  end
+            ::Rbac.filtered(vms)
+          }
+        end
+
         connection :vms, !Vm.connection_type, "List available virtual machines" do
           argument :tags, types[types.String]
 

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -34,6 +34,19 @@ module ManageIQ
           }
         end
 
+        connection :vmware_providers, !ProviderVmware.connection_type, "List available VmWare providers" do
+          argument :tags, types[types.String]
+
+          resolve ->(_obj, args, _ctx) {
+            providers = if args[:tags]
+                          ::ManageIQ::Providers::Vmware::InfraManager.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
+                        else
+                          ::ManageIQ::Providers::Vmware::InfraManager.all
+                        end
+            ::Rbac.filtered(providers)
+          }
+        end
+
         connection :providers, !Provider.connection_type, "List available providers" do
           argument :tags, types[types.String]
 

--- a/lib/manageiq/graphql/types/query.rb
+++ b/lib/manageiq/graphql/types/query.rb
@@ -8,19 +8,6 @@ module ManageIQ
         field :node,  ::GraphQL::Relay::Node.field
         field :nodes, ::GraphQL::Relay::Node.plural_field
 
-        connection :vmware_hosts, !HostVmware.connection_type, "List available VmWare hosts" do
-          argument :tags, types[types.String]
-
-          resolve ->(_obj, args, _ctx) {
-            hosts = if args[:tags]
-                      ::ManageIQ::Providers::Vmware::InfraManager::Host.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
-                    else
-                      ::ManageIQ::Providers::Vmware::InfraManager::Host.all
-                    end
-            ::Rbac.filtered(hosts)
-          }
-        end
-
         connection :hosts, !Host.connection_type, "List available hosts" do
           argument :tags, types[types.String]
 
@@ -34,16 +21,16 @@ module ManageIQ
           }
         end
 
-        connection :vmware_providers, !ProviderVmware.connection_type, "List available VmWare providers" do
+        connection :hosts_vmware, !HostVmware.connection_type, "List available VmWare hosts" do
           argument :tags, types[types.String]
 
           resolve ->(_obj, args, _ctx) {
-            providers = if args[:tags]
-                          ::ManageIQ::Providers::Vmware::InfraManager.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
-                        else
-                          ::ManageIQ::Providers::Vmware::InfraManager.all
-                        end
-            ::Rbac.filtered(providers)
+            hosts = if args[:tags]
+                      ::ManageIQ::Providers::Vmware::InfraManager::Host.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
+                    else
+                      ::ManageIQ::Providers::Vmware::InfraManager::Host.all
+                    end
+            ::Rbac.filtered(hosts)
           }
         end
 
@@ -55,6 +42,19 @@ module ManageIQ
                           ::ExtManagementSystem.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
                         else
                           ::ExtManagementSystem.all
+                        end
+            ::Rbac.filtered(providers)
+          }
+        end
+
+        connection :providers_vmware, !ProviderVmware.connection_type, "List available VmWare providers" do
+          argument :tags, types[types.String]
+
+          resolve ->(_obj, args, _ctx) {
+            providers = if args[:tags]
+                          ::ManageIQ::Providers::Vmware::InfraManager.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
+                        else
+                          ::ManageIQ::Providers::Vmware::InfraManager.all
                         end
             ::Rbac.filtered(providers)
           }
@@ -85,19 +85,6 @@ module ManageIQ
           }
         end
 
-        connection :vmware_vms, !VmVmware.connection_type, "List available Vmware virtual machines" do
-          argument :tags, types[types.String]
-
-          resolve ->(_obj, args, _ctx) {
-            vms = if args[:tags]
-                    ::ManageIQ::Providers::Vmware::InfraManager::Vm.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
-                  else
-                    ::ManageIQ::Providers::Vmware::InfraManager::Vm.all
-                  end
-            ::Rbac.filtered(vms)
-          }
-        end
-
         connection :vms, !Vm.connection_type, "List available virtual machines" do
           argument :tags, types[types.String]
 
@@ -106,6 +93,19 @@ module ManageIQ
                     ::Vm.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
                   else
                     ::Vm.all
+                  end
+            ::Rbac.filtered(vms)
+          }
+        end
+
+        connection :vms_vmware, !VmVmware.connection_type, "List available Vmware virtual machines" do
+          argument :tags, types[types.String]
+
+          resolve ->(_obj, args, _ctx) {
+            vms = if args[:tags]
+                    ::ManageIQ::Providers::Vmware::InfraManager::Vm.find_tagged_with(:all => args[:tags].join(" "), :ns => Classification::DEFAULT_NAMESPACE)
+                  else
+                    ::ManageIQ::Providers::Vmware::InfraManager::Vm.all
                   end
             ::Rbac.filtered(vms)
           }

--- a/lib/manageiq/graphql/types/vm.rb
+++ b/lib/manageiq/graphql/types/vm.rb
@@ -1,11 +1,9 @@
 module ManageIQ
   module GraphQL
     module Types
-      Vm = ::GraphQL::ObjectType.define do
+      Vm = ::GraphQL::InterfaceType.define do
         name 'Vm'
         description 'A Virtual Machine is a software implementation of a system that functions similar to a physical machine. Virtual machines utilize the hardware infrastructure of a physical host, or a set of physical hosts, to provide a scalable and on-demand method of system provisioning.'
-        implements ::GraphQL::Relay::Node.interface
-        interfaces [Taggable]
 
         global_id_field :id
         field :database_id,

--- a/lib/manageiq/graphql/types/vm_vmware.rb
+++ b/lib/manageiq/graphql/types/vm_vmware.rb
@@ -1,0 +1,11 @@
+module ManageIQ
+  module GraphQL
+    module Types
+      VmVmware = ::GraphQL::ObjectType.define do
+        name "VmVmware"
+        implements ::GraphQL::Relay::Node.interface
+        interfaces [Taggable, Vm]
+      end
+    end
+  end
+end

--- a/spec/integration/mutations/perform_vm_power_operation_spec.rb
+++ b/spec/integration/mutations/perform_vm_power_operation_spec.rb
@@ -1,7 +1,7 @@
 require "manageiq_helper"
 
 RSpec.describe 'performVmPowerOperation' do
-  let(:vm) { FactoryGirl.create(:vm) }
+  let(:vm) { FactoryGirl.create(:vm_vmware) }
 
   as_user do
     let(:query) do

--- a/spec/integration/relay_spec.rb
+++ b/spec/integration/relay_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Relay specification compliance (integration)" do
     context "given an object with an ID" do
       as_user do
         before do
-          FactoryGirl.create(:vm, :name => "Sooper Special VM")
+          FactoryGirl.create(:vm_vmware, :name => "Sooper Special VM")
 
           execute_graphql <<~QUERY
             {

--- a/spec/integration/tagging_spec.rb
+++ b/spec/integration/tagging_spec.rb
@@ -2,7 +2,7 @@ require "manageiq_helper"
 
 RSpec.describe "Tagging" do
   describe "addTags mutation" do
-    let(:taggable) { FactoryGirl.create(:vm, :name => "Sooper Cool VM") }
+    let(:taggable) { FactoryGirl.create(:vm_vmware, :name => "Sooper Cool VM") }
 
     let(:mutation) do
       <<~MUTATION
@@ -53,7 +53,7 @@ RSpec.describe "Tagging" do
     end
 
     let(:taggable) do
-      FactoryGirl.create(:vm, :name => "Sooper Cool VM", :tags => tags)
+      FactoryGirl.create(:vm_vmware, :name => "Sooper Cool VM", :tags => tags)
     end
 
     let(:mutation) do

--- a/spec/integration/vms_spec.rb
+++ b/spec/integration/vms_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Vm queries" do
   describe "'vms' field" do
     as_user do
       before do
-        FactoryGirl.create(:vm, :name => "Alice's VM")
+        FactoryGirl.create(:vm_vmware, :name => "Alice's VM")
       end
 
       it "will return the specified fields of all vms" do


### PR DESCRIPTION
Extracts interfaces for vms, hosts and providers. Concrete types have been provided for vmware for illustration - these can later be separated/extracted out.

Queries can be performed on the concrete types (e.g. `query { vmware_vms { edges { node { name }}}}`) or across all implementations of the interface (`query { vms { edges { node { name }}}}`). Non-substitutable specializations in concrete types can be retrieved in the latter query by use of fragments (see http://graphql.org/learn/queries/#inline-fragments).

TODO: try to figure out how the `resolve_type` function on the schema can not have to know about provider-specific concrete types. May leave this as a follow up.

Resolves https://www.pivotaltracker.com/story/show/157486444