### PR TITLE
Import the index.js file directly rather than the directory

### DIFF
--- a/app/javascript/packs/graphql-explorer.js
+++ b/app/javascript/packs/graphql-explorer.js
@@ -1,4 +1,4 @@
-import GraphQLExplorer from "../graphql-explorer";
+import GraphQLExplorer from "../graphql-explorer/index";
 
 window.MiqReact.componentRegistry.register({
   name: "graphql_explorer",


### PR DESCRIPTION
This fixes a build issue where UglifyJS was failing in production
mode.

Specifically the error was:
ERROR in manageiq-graphql/graphql-explorer-7be988ee1dd5c4de948f.js from UglifyJs
Unexpected token: punc ()) [../manageiq-graphql-55a4ec981f49/app/javascript/graphql-explorer/index.js:5,15][manageiq-graphql/graphql-explorer-7be988ee1dd5c4de948f.js:60,58]

@himdel @imtayadeway 

This will fix the container build issues