### PR TITLE
Add babel presets used in .babelrc as yarn devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "react": "^16.2.0"
   },
   "devDependencies": {
-    "babel-preset-env": "^1.6.0",
-    "babel-preset-react": "^6.24.1"
+    "babel-preset-env": "~1.6.1",
+    "babel-preset-es2015": "~6.24.1",
+    "babel-preset-react": "~6.24.1",
+    "babel-preset-stage-1": "~6.24.1"
   }
 }


### PR DESCRIPTION
This is a follow up to https://github.com/ManageIQ/manageiq-graphql/pull/54, which should prevent some people from a failing `update:ui` with

```
Module build failed: Error: Couldn't find preset "es2015" relative to directory "/Users/stomsa/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/bundler/gems/manageiq-graphql-ce3bd9ed5bef"
```

Cc @Glutexo, @carbonin, @imtayadeway 