### PR TITLE
Update component registry syntax

### DIFF
--- a/app/javascript/packs/graphql-explorer.js
+++ b/app/javascript/packs/graphql-explorer.js
@@ -1,6 +1,8 @@
 import GraphQLExplorer from "../graphql-explorer";
 
-window.MiqReact.componentRegistry.register({
+const { componentRegistry } = window.ManageIQ.react;
+
+componentRegistry.register({
   name: "graphql_explorer",
   type: GraphQLExplorer
 });


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-ui-classic/pull/3579/ made
`MiqReact` obsolete, so this change is necessary to continue mounting
the GraphQL explorer.

Thank you to @aparnakarve who provided the solution.

NOTE: this is a blocker for https://github.com/ManageIQ/manageiq-ui-classic/pull/3357

/cc @himdel