### PR TITLE
Replace react registry with MIQ addReact interface.

### DIFF
--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -1,0 +1,3 @@
+import GraphQLExplorer from "../graphql-explorer";
+
+ManageIQ.component.addReact('GraphQLExplorer', GraphQLExplorer);

--- a/app/javascript/packs/graphql-explorer.js
+++ b/app/javascript/packs/graphql-explorer.js
@@ -1,8 +1,0 @@
-import GraphQLExplorer from "../graphql-explorer";
-
-const { componentRegistry } = window.ManageIQ.react;
-
-componentRegistry.register({
-  name: "graphql_explorer",
-  type: GraphQLExplorer
-});


### PR DESCRIPTION
MIQ-ui-classic has moved to different mounting mechanism form React component a while ago. I've recently noticed that grapql plugin is still using the old one.

This is a part of a code maintenance on ui-classic side.

Should be merged with https://github.com/ManageIQ/manageiq-ui-classic/pull/4877