### PR TITLE
Fix rgb with 4 arguments in new codemirror yonde.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "codemirror": "~5.40",
     "graphiql": "^0.11.11",
     "react": "^16.2.0"
   },


### PR DESCRIPTION
the problem was introduced in codemirror 5.45, we're failing precompile on that, temporarily fixing to older version.

Same problem as https://github.com/ManageIQ/manageiq-graphql/pull/71 (but master),
temporary because I'm working on moving codemirror off the asset pipeline.

Cc @simaishi 