### PR TITLE
Fix spec failure

### DIFF
--- a/manageiq-graphql.gemspec
+++ b/manageiq-graphql.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_runtime_dependency("graphql", "~> 1.7")
+  s.add_runtime_dependency("graphql", "~> 1.7", "< 1.10.6")
   s.add_runtime_dependency("graphql-batch", "~> 0.3.8")
   s.add_runtime_dependency("graphql-preload", "~> 1.0")
 


### PR DESCRIPTION
- Global object id not compatible with latest relay spec, constraining the graphql gem version for now.