### PR TITLE
cleanup .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 ---
-dist: xenial
 language: ruby
 rvm:
 - 2.5.8
 - 2.6.6
-sudo: false
 cache: bundler
 env:
   global:


### PR DESCRIPTION
we don't need to list the default distro and we also no longer need `sudo: false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration