### PR TITLE
Require 'rspec/mocks' to resolve spec failures

### DIFF
--- a/spec/manageiq_helper.rb
+++ b/spec/manageiq_helper.rb
@@ -9,6 +9,8 @@ require File.expand_path("../manageiq/config/environment", __FILE__)
 
 # Configure rspec-rails
 require 'rspec/rails'
+require 'rspec/mocks'
+
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Fixes:
```
An error occurred while loading ./spec/integration/authentication_spec.rb.
Failure/Error: Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }

NameError:
  uninitialized constant RSpec::Mocks::ExampleMethods
 /home/grare/adam/src/manageiq/manageiq/spec/support/evm_spec_helper.rb:13:in `<module:EvmSpecHelper>'
 /home/grare/adam/src/manageiq/manageiq/spec/support/evm_spec_helper.rb:12:in `<top (required)>'
 ./spec/manageiq_helper.rb:23:in `block in <top (required)>'
 ./spec/manageiq_helper.rb:23:in `each'
 ./spec/manageiq_helper.rb:23:in `<top (required)>'
 ./spec/integration/authentication_spec.rb:1:in `require'
 ./spec/integration/authentication_spec.rb:1:in `<top (required)>'
```