### PR TITLE
Rails 6.0

### DIFF
--- a/manageiq-graphql.gemspec
+++ b/manageiq-graphql.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_runtime_dependency("graphql", "~> 1.7", "< 1.10.6")
-  s.add_runtime_dependency("graphql-batch", "~> 0.3.8")
-  s.add_runtime_dependency("graphql-preload", "~> 1.0")
+  s.add_runtime_dependency("graphql-batch", "~> 0.4.3")
+  s.add_runtime_dependency("graphql-preload", "=2.1.0.1")
 
   s.add_development_dependency("codeclimate-test-reporter", "~> 1.0.0")
   s.add_development_dependency("rspec-rails", "~> 3.7")

--- a/spec/manageiq_helper.rb
+++ b/spec/manageiq_helper.rb
@@ -9,6 +9,8 @@ require File.expand_path("../manageiq/config/environment", __FILE__)
 
 # Configure rspec-rails
 require 'rspec/rails'
+require 'rspec/mocks'
+
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!

--- a/spec/support/integration_macros.rb
+++ b/spec/support/integration_macros.rb
@@ -101,7 +101,7 @@ module IntegrationMacros
   # Creates the minimum required records to have a functional
   # integration test
   def create_primordials
-    Tenant.create!(:use_config_for_attributes => false)
+    Tenant.root_tenant || Tenant.create!(:use_config_for_attributes => false)
     allow(MiqServer).to receive(:my_guid).and_return(server.guid)
     MiqServer.my_server_clear_cache
   end


### PR DESCRIPTION
We are using our custom release of `graphql-preload` to handle some Rails 6 compatibility issues:

https://github.com/ManageIQ/graphql-preload/tree/graphql_preload_2_1_0

Links
-----

* Epic:  https://github.com/ManageIQ/manageiq/issues/19977
* Current Cross Repo: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/179