### PR TITLE
[LASKER] Lockdown tests to use ruby 2.6.6 per ManageIQ/manageiq#19678

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: ruby
 rvm:
-- 2.5.8
 - 2.6.6
 cache: bundler
 env:


### PR DESCRIPTION
Lockdown tests to use ruby 2.6.6 per ManageIQ/manageiq#19678