### PR TITLE
Drop redundant rspec-rails dependency also defined in core

### DIFF
--- a/manageiq-graphql.gemspec
+++ b/manageiq-graphql.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("codeclimate-test-reporter", "~> 1.0.0")
   s.add_development_dependency("manageiq-style")
-  s.add_development_dependency("rspec-rails", "~> 3.7")
   s.add_development_dependency("simplecov")
   s.add_development_dependency("spring")
   s.add_development_dependency("spring-commands-rspec")


### PR DESCRIPTION
Workaround a bug in bundler 2.2.23:
"When a development dependency was duplicated inside the gemspec and
Gemfile with the same requirements, we went from printing a warning to
removing the gem altogether."

See also https://github.com/rubygems/rubygems/pull/4751/files